### PR TITLE
Refactor `Files`, `DataFiles` and `PredFiles` to be `StrEnums`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -171,7 +171,7 @@ All notable changes to this project will be documented in this file. Dates are d
 - add changelog.md [`0621282`](https://github.com/janosh/matbench-discovery/commit/0621282b0ed6ca397b6293e8d6f2bcbaac736468)
 - add models/chgnet/ctk_struct_traj.py and models/wrenformer/analyze_wrenformer.py [`c9fed5a`](https://github.com/janosh/matbench-discovery/commit/c9fed5ae7bddc02c3fbb2160a00b4e8822b1a179)
 - add data/mp/get_mp_traj.py to save a snapshot of all MP ionic steps on 2023-03-15 to be released as MBD canonical training set [`76647e3`](https://github.com/janosh/matbench-discovery/commit/76647e37b9fdfbbc77fb2317ad2a0cf3369638a9)
-- move load_df_wbm_preds+PRED_FILES from matbench_discovery/{data->preds}.py [`387184c`](https://github.com/janosh/matbench-discovery/commit/387184caa50c27e2574a86a4bef65a1628434378)
+- move load_df_wbm_preds+PredFiles from matbench_discovery/{data->preds}.py [`387184c`](https://github.com/janosh/matbench-discovery/commit/387184caa50c27e2574a86a4bef65a1628434378)
 - add site/src/figs/(largest-fp-diff-each-error-models|largest-each-errors-fp-diff-models).svelte [`4b6e83a`](https://github.com/janosh/matbench-discovery/commit/4b6e83a13816f9b8dcc911af5cbe1d79f05bf876)
 - move /paper/preprint to /paper [`8a0c3bb`](https://github.com/janosh/matbench-discovery/commit/8a0c3bb47609cf784d95e7499394785487383d82)
 - add global STABILITY_THRESHOLD to consistently parametrize across the codebase when materials count as thermodynamically stable [`70b2b1d`](https://github.com/janosh/matbench-discovery/commit/70b2b1d81476e5913802d8286f281af9385a8754)

--- a/data/mp/build_phase_diagram.py
+++ b/data/mp/build_phase_diagram.py
@@ -19,7 +19,7 @@ from pymatviz.io import save_fig
 from tqdm import tqdm
 
 from matbench_discovery import MP_DIR, ROOT, today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.energy import get_e_form_per_atom, get_elemental_ref_entries
 
 module_dir = os.path.dirname(__file__)
@@ -64,7 +64,9 @@ with gzip.open(f"{module_dir}/{today}-ppd-mp.pkl.gz", "wb") as zip_file:
 
 
 # %% build phase diagram with both MP entries + WBM entries
-df_wbm = pd.read_json(DATA_FILES.wbm_computed_structure_entries).set_index(Key.mat_id)
+df_wbm = pd.read_json(DataFiles.wbm_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 
 # using ComputedStructureEntry vs ComputedEntry here is important as CSEs receive
 # more accurate energy corrections that take into account peroxide/superoxide nature
@@ -102,7 +104,7 @@ with gzip.open(mp_pd_elem_ref_entries_path, "wt") as file:
     json.dump(elemental_ref_entries, file, default=lambda x: x.as_dict())
 
 
-df_mp = pd.read_csv(DATA_FILES.mp_energies, na_filter=False).set_index(Key.mat_id)
+df_mp = pd.read_csv(DataFiles.mp_energies.path, na_filter=False).set_index(Key.mat_id)
 
 
 # %%

--- a/data/mp/eda_mp_trj.py
+++ b/data/mp/eda_mp_trj.py
@@ -28,7 +28,7 @@ from pymatviz.utils import si_fmt
 from tqdm import tqdm
 
 from matbench_discovery import MP_DIR, PDF_FIGS, ROOT, SITE_FIGS
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey
 
 __author__ = "Janosh Riebesell"
@@ -41,7 +41,7 @@ data_page = f"{ROOT}/site/src/routes/data"
 mp_occu_counts = pd.read_json(
     f"{data_page}/mp-element-counts-by-occurrence.json", typ="series"
 )
-df_mp = pd.read_csv(DATA_FILES.mp_energies, na_filter=False).set_index(Key.mat_id)
+df_mp = pd.read_csv(DataFiles.mp_energies.path, na_filter=False).set_index(Key.mat_id)
 
 
 # %% --- load preprocessed MPtrj summary data if available ---

--- a/data/mp/get_mp_energies.py
+++ b/data/mp/get_mp_energies.py
@@ -18,7 +18,7 @@ from pymatviz.utils import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import STABILITY_THRESHOLD, today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 
 __author__ = "Janosh Riebesell"
 __date__ = "2023-01-10"
@@ -60,7 +60,9 @@ df_mp.energy_type.value_counts().plot.pie(backend=PLOTLY, autopct="%1.1f%%")
 
 
 # %%
-df_cse = pd.read_json(DATA_FILES.mp_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.mp_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 
 df_cse[Key.structure] = [
     Structure.from_dict(cse[Key.structure]) for cse in tqdm(df_cse.entry)
@@ -77,8 +79,8 @@ spg_nums = df_mp[Key.wyckoff].str.split("_").str[2].astype(int)
 # make sure all our spacegroup numbers match MP's
 assert (spg_nums.sort_index() == df_spg["number"].sort_index()).all()
 
-df_mp.to_csv(DATA_FILES.mp_energies)
-# df = pd.read_csv(DATA_FILES.mp_energies, na_filter=False).set_index(Key.mat_id)
+df_mp.to_csv(DataFiles.mp_energies.path)
+# df = pd.read_csv(DataFiles.mp_energies.path, na_filter=False).set_index(Key.mat_id)
 
 
 # %% reproduce fig. 1b from https://arxiv.org/abs/2001.10591 (as data consistency check)

--- a/data/wbm/compare_cse_vs_ce_mp_2020_corrections.py
+++ b/data/wbm/compare_cse_vs_ce_mp_2020_corrections.py
@@ -18,11 +18,13 @@ from pymatviz.io import save_fig
 from tqdm import tqdm
 
 from matbench_discovery import ROOT, today
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.energy import get_e_form_per_atom
 from matbench_discovery.plots import plt
 
-df_cse = pd.read_json(DATA_FILES.wbm_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 
 cses = [ComputedStructureEntry.from_dict(dct) for dct in tqdm(df_cse[Key.cse])]
 

--- a/data/wbm/compile_wbm_test_set.py
+++ b/data/wbm/compile_wbm_test_set.py
@@ -26,7 +26,7 @@ from pymatviz.io import save_fig
 from tqdm import tqdm
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS, WBM_DIR, today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.energy import get_e_form_per_atom
 from matbench_discovery.enums import MbdKey
 
@@ -547,7 +547,7 @@ assert df_summary.e_correction_per_atom_mp2020.mean().round(4) == -0.1069
 
 
 # %%
-with gzip.open(DATA_FILES.mp_patched_phase_diagram, "rb") as zip_file:
+with gzip.open(DataFiles.mp_patched_phase_diagram.path, "rb") as zip_file:
     ppd_mp: PatchedPhaseDiagram = pickle.load(zip_file)  # noqa: S301
 
 
@@ -644,7 +644,7 @@ except KeyError:
 
 # %% mark WBM materials with matching prototype in MP or duplicate prototypes
 # in WBM (keeping only the lowest energy one)
-df_mp = pd.read_csv(DATA_FILES.mp_energies, index_col=0)
+df_mp = pd.read_csv(DataFiles.mp_energies.path, index_col=0)
 
 # mask WBM materials with matching prototype in MP
 mask_proto_in_mp = df_summary[Key.wyckoff].isin(df_mp[Key.wyckoff])
@@ -675,8 +675,10 @@ df_summary.round(6).to_csv(f"{WBM_DIR}/{today}-wbm-summary.csv.gz")
 
 # %% only here to load data for later inspection
 if False:
-    df_summary = pd.read_csv(DATA_FILES.wbm_summary).set_index(Key.mat_id)
-    df_wbm = pd.read_json(DATA_FILES.wbm_cses_plus_init_structs).set_index(Key.mat_id)
+    df_summary = pd.read_csv(DataFiles.wbm_summary.path).set_index(Key.mat_id)
+    df_wbm = pd.read_json(DataFiles.wbm_cses_plus_init_structs.path).set_index(
+        Key.mat_id
+    )
 
     df_wbm[Key.cse] = [
         ComputedStructureEntry.from_dict(dct) for dct in tqdm(df_wbm[Key.cse])

--- a/data/wbm/eda_wbm.py
+++ b/data/wbm/eda_wbm.py
@@ -24,7 +24,7 @@ from pymatviz.utils import PLOTLY, si_fmt, si_fmt_int
 
 from matbench_discovery import PDF_FIGS, ROOT, SITE_FIGS, STABILITY_THRESHOLD
 from matbench_discovery import plots as plots
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.energy import mp_elem_ref_entries
 from matbench_discovery.enums import MbdKey, Model
 from matbench_discovery.preds import df_each_err
@@ -37,7 +37,7 @@ data_page = f"{ROOT}/site/src/routes/data"
 
 
 # %% load MP training set
-df_mp = pd.read_csv(DATA_FILES.mp_energies, na_filter=False, na_values=[])
+df_mp = pd.read_csv(DataFiles.mp_energies.path, na_filter=False, na_values=[])
 
 df_mp[df_mp[Key.formula].isna()]
 
@@ -384,7 +384,7 @@ df_sym_change = (
 
 
 # %%
-df_wbm_structs = pd.read_json(DATA_FILES.wbm_cses_plus_init_structs).set_index(
+df_wbm_structs = pd.read_json(DataFiles.wbm_cses_plus_init_structs.path).set_index(
     Key.mat_id
 )
 

--- a/matbench_discovery/__init__.py
+++ b/matbench_discovery/__init__.py
@@ -56,9 +56,6 @@ today = timestamp.split("@")[0]
 warnings.filterwarnings(action="ignore", category=UserWarning, module="pymatgen")
 
 
-with open(f"{FIGSHARE_DIR}/1.0.0.json") as file:
-    FIGSHARE_URLS = json.load(file)
-
 # --- start global plot settings
 px.defaults.labels = (  # Quantity last to get precedence over Key and Model
     MbdKey.val_label_dict() | Model.key_val_dict() | Quantity.key_val_dict()

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -139,8 +139,6 @@ class Files(StrEnum):
                 if is_ipython or sys.stdin.isatty()
                 else "y"
             )
-            if os.getenv("CI"):
-                answer = "n"
             if answer.lower().strip() == "y":
                 if not is_ipython:
                     print(f"Downloading {key!r} from {url} to {abs_path} for caching")

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -146,10 +146,11 @@ class Files(StrEnum):
             is_ipython = hasattr(__builtins__, "__IPYTHON__")
             # default to 'y' if not in interactive session, and user can't answer
             answer = "" if is_ipython or sys.stdin.isatty() else "y"
-            answer = input(
-                f"{abs_path!r} associated with {key=} does not exist. Would you like"
-                " to download it now? This will cache the file for future use. [y/n] "
-            )
+            if answer == "":
+                answer = input(
+                    f"{abs_path!r} associated with {key=} does not exist. Download it "
+                    "now? This will cache the file for future use. [y/n] "
+                )
             if answer.lower().strip() == "y":
                 if not is_ipython:
                     print(f"Downloading {key!r} from {url} to {abs_path} for caching")

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -3,21 +3,15 @@
 https://figshare.com/articles/dataset/22715158
 """
 
-import gzip
-import json
 import os
-import pickle
 import sys
-import urllib.error
-import urllib.request
 from collections.abc import Callable
+from enum import StrEnum
 from glob import glob
-from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import pandas as pd
-from monty.json import MontyDecoder
-from pymatgen.analysis.phase_diagram import PatchedPhaseDiagram
+import requests
 from pymatviz.enums import Key
 from tqdm import tqdm
 
@@ -31,9 +25,9 @@ figshare_versions = sorted(
     x.split(os.path.sep)[-1].split(".json")[0] for x in glob(f"{FIGSHARE_DIR}/*.json")
 )
 # directory to cache downloaded data files
-default_cache_dir = os.getenv(
+DEFAULT_CACHE_DIR = os.getenv(
     "MATBENCH_DISCOVERY_CACHE_DIR",
-    f"{os.path.expanduser('~/.cache/matbench-discovery')}/{figshare_versions[-1]}",
+    f"{os.path.expanduser('~/.cache/matbench-discovery')}",
 )
 
 
@@ -47,105 +41,6 @@ def as_dict_handler(obj: Any) -> dict[str, Any] | None:
     except AttributeError:
         return None  # replace unhandled objects with None in serialized data
         # removes e.g. non-serializable AseAtoms from M3GNet relaxation trajectories
-
-
-def load(
-    key: str,
-    *,
-    version: str = figshare_versions[-1],
-    cache_dir: str | Path = default_cache_dir,
-    hydrate: bool = False,
-    **kwargs: Any,
-) -> pd.DataFrame | PatchedPhaseDiagram:
-    """Download parts of or the full MP training data and WBM test data as pandas
-    DataFrames. The full training and test sets are each about ~500 MB as compressed
-    JSON which will be cached locally to cache_dir for faster re-loading unless
-    cache_dir is set to None.
-
-    See matbench_discovery.data.DATA_FILES for recognized data keys. See [here]
-    (https://janosh.github.io/matbench-discovery/contribute#--direct-download) for file
-    descriptions.
-
-    Args:
-        key (str): Which parts of the MP/WBM data to load. Must be one of
-            list(DATA_FILES).
-        version (str, optional): Which version of the dataset to load. Defaults to
-            latest version of data files published to Figshare. Pass any invalid version
-            to see valid options.
-        cache_dir (str, optional): Where to cache data files on local drive. Defaults to
-            '~/.cache/matbench-discovery'. Set to None to disable caching.
-        hydrate (bool, optional): Whether to hydrate pymatgen objects. If False,
-            Structures and ComputedStructureEntries are returned as dictionaries which
-            can be hydrated on-demand with df.col.map(Structure.from_dict). Defaults to
-            False as it noticeably increases load time.
-        **kwargs: Additional keyword arguments passed to pandas.read_json or read_csv,
-            depending on which file is loaded.
-
-    Raises:
-        ValueError: On bad version number or bad data_key.
-
-    Returns:
-        pd.DataFrame: Single dataframe or dictionary of dfs if multiple data requested.
-    """
-    if version not in figshare_versions:
-        raise ValueError(f"Unexpected {version=}. Must be one of {figshare_versions}.")
-
-    if not isinstance(key, str) or key not in DATA_FILES:
-        raise ValueError(f"Unknown {key=}, must be one of {list(DATA_FILES)}.")
-
-    with open(f"{FIGSHARE_DIR}/{version}.json") as json_file:
-        file_urls = json.load(json_file)["files"]
-
-    file_path = DataFiles.__dict__[key]
-
-    cache_path = f"{cache_dir}/{file_path}"
-    if not os.path.isfile(cache_path):  # download from Figshare URL
-        url = file_urls[key][0]
-        print(f"Downloading {key!r} from {url}")
-        try:
-            # ensure directory exists
-            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-            # download and save to disk
-            urllib.request.urlretrieve(url, cache_path)
-            print(f"Cached {key!r} to {cache_path!r}")
-        except urllib.error.HTTPError as exc:
-            raise ValueError(f"Bad {url=}") from exc
-        except Exception:
-            print(f"\n\nvariable dump:\n{file_path=},\n{url=}")
-            raise
-
-    print(f"Loading {key!r} from cached file at {cache_path!r}")
-    if ".pkl" in file_path:  # handle key='mp_patched_phase_diagram' separately
-        with gzip.open(cache_path, "rb") as zip_file:
-            return pickle.load(zip_file)  # noqa: S301
-    if ".pth" in file_path:  # handle model checkpoints (e.g. key='alignn_checkpoint')
-        return cache_path
-
-    csv_ext = (".csv", ".csv.gz", ".csv.bz2")
-    reader = pd.read_csv if file_path.endswith(csv_ext) else pd.read_json
-    try:
-        df_out = reader(cache_path, **kwargs)
-    except Exception:
-        print(f"\n\nvariable dump:\n{file_path=},\n{reader=}\n{kwargs=}")
-        raise
-
-    if Key.mat_id in df_out:
-        df_out = df_out.set_index(Key.mat_id)
-    if hydrate:
-        for col in df_out:
-            if not isinstance(df_out[col].iloc[0], dict):
-                continue
-            try:
-                # convert dicts to pymatgen Structures and ComputedStructureEntries
-                df_out[col] = [
-                    MontyDecoder().process_decoded(dct)
-                    for dct in tqdm(df_out[col], desc=col)
-                ]
-            except Exception:
-                print(f"\n\nvariable dump:\n{col=},\n{df_out[col]=}")
-                raise
-
-    return df_out
 
 
 def glob_to_df(
@@ -182,96 +77,123 @@ def glob_to_df(
     return pd.concat(sub_dfs.values())
 
 
-class Files(dict):  # type: ignore[type-arg]
-    """Files instance inherits from dict so that .values(), items(), etc. are supported
-    but also allows accessing attributes by dot notation. E.g. FILES.some_file_key.
-    This enables tab completion in IDEs and auto-updating attribute names across the
-    code base when changing the key of a file.
-    """
+def download_file(file_path: str, url: str) -> None:
+    """Download the file from the given URL to the given file path."""
+    file_dir = os.path.dirname(file_path)
+    os.makedirs(file_dir, exist_ok=True)
+    try:
+        response = requests.get(url, timeout=5)
 
-    def __init__(
-        self, root: str = default_cache_dir, key_map: dict[str, str] | None = None
-    ) -> None:
-        """Create a Files instance.
+        response.raise_for_status()
 
-        Args:
-            root (str, optional): Root directory used to absolufy every file path.
-            Defaults to '~/.cache/matbench-discovery/[latest_figshare_release]' where
-                latest_figshare_release is e.g. 1.0.0. Can also be set through env var
-                MATBENCH_DISCOVERY_CACHE_DIR.
-            key_map (dict[str, str], optional): Mapping from attribute names to keys in
-                the dict. Useful if you want to have keys like 'foo+bar' that are not
-                valid Python identifiers. Defaults to None.
+        with open(file_path, "wb") as file:
+            file.write(response.content)
+    except requests.exceptions.RequestException as exc:
+        print(f"Error downloading {url=}\nto {file_path=}.\n{exc!s}")
+
+
+class Files(StrEnum):
+    """Enum of data files with associated file directories and URLs."""
+
+    def __new__(cls, file_path: str, url: str, base: str = DEFAULT_CACHE_DIR) -> Self:
+        """Create a new member of the FileUrls enum with a given URL where to load the
+        file from and directory where to save it to.
         """
-        # callback that's triggered when a file corresponding to a class attribute does
-        # not exist. gets passed key and missing filepath. set to None to disable
-        self._on_not_found: Callable[[str, str], None] | None = lambda key, path: print(
-            f"Warning: {path!r} associated with {key=} does not exist.",
-            file=sys.stderr,
-        )
+        obj = str.__new__(cls)
+        if len(url) == 33:
+            # looks like a Google Drive ID, turn into direct download link
+            url = f"https://drive.usercontent.google.com/download?id={url}&confirm=t"
+        file_name = file_path.split("/")[-1]
+        obj._value_ = file_name
 
-        rel_paths = {
-            (key_map or {}).get(key, key): file
-            for key, file in type(self).__dict__.items()
-            if not key.startswith("_")
-        }
-        abs_paths = {key: f"{root}/{file}" for key, file in rel_paths.items()}
-        self.__dict__ = abs_paths
-        super().__init__(abs_paths)
+        obj._rel_path = file_path  # type: ignore[attr-defined] # noqa: SLF001
+        obj._file_path = f"{base}/{file_path}"  # type: ignore[attr-defined] # noqa: SLF001
+        obj._url = url  # type: ignore[attr-defined] # noqa: SLF001
+        return obj
 
-    def __getattribute__(self, key: str) -> str:
-        """Override __getattr__ to check if key matches a file attribute."""
-        filepath = super().__getattribute__(key)
-        if key in self and not os.path.isfile(filepath) and self._on_not_found:
-            self._on_not_found(key, filepath)
-        return filepath
+    def __str__(self) -> str:
+        """File path associated with the file URL. Use str(DataFiles.some_key) if you
+        want the absolute file path without auto-downloading the file if it doesn't
+        exist yet, e.g. for use in script that generates the file in the first place.
+        """
+        return self._file_path  # type: ignore[attr-defined]
+
+    @property
+    def path(self) -> str:
+        """Return the file path associated with the file URL if it exists, otherwise
+        download the file first, then return the path.
+        """
+        key, url, file_path = self.name, self._url, self._file_path  # type: ignore[attr-defined]
+        if not os.path.isfile(file_path):
+            is_ipython = hasattr(__builtins__, "__IPYTHON__")
+            # default to 'y' if not in interactive session, and user can't answer
+            answer = "" if is_ipython or sys.stdin.isatty() else "y"
+            answer = input(
+                f"{file_path!r} associated with {key=} does not exist. Would you like"
+                " to download it now? This will cache the file for future use. [y/n] "
+            )
+            if answer.lower().strip() == "y":
+                if not is_ipython:
+                    print(f"Downloading {key!r} from {url} to {file_path} for caching")
+                download_file(file_path, url)
+        return file_path
 
 
 class DataFiles(Files):
-    """Data files provided by Matbench Discovery.
-    See https://janosh.github.io/matbench-discovery/contribute for data descriptions.
-    """
+    """Enum of data files with associated file directories and URLs."""
 
-    def _on_not_found(self, key: str, path: str) -> None:  # type: ignore[override]
-        msg = (
-            f"{path!r} associated with {key=} does not exist. Would you like to "
-            "download it now? This will cache the file for future use."
-        )
-
-        # default to 'y' if not in interactive session, and user can't answer
-        answer = "" if sys.stdin.isatty() else "y"
-        while answer not in ("y", "n"):
-            answer = input(f"{msg} [y/n] ").lower().strip()
-        if answer == "y":
-            load(key)  # download and cache data file
-
-    # TODO maybe set attrs to None and load file names from Figshare json
     mp_computed_structure_entries = (
-        "mp/2023-02-07-mp-computed-structure-entries.json.gz"
+        "mp/2023-02-07-mp-computed-structure-entries.json.gz",
+        "https://figshare.com/ndownloader/files/40344436",
     )
-    mp_elemental_ref_entries = "mp/2023-02-07-mp-elemental-reference-entries.json.gz"
-    mp_energies = "mp/2023-01-10-mp-energies.csv.gz"
-    mp_patched_phase_diagram = "mp/2023-02-07-ppd-mp.pkl.gz"
-    mp_trj_extxyz = "mp/2023-11-22-mp-trj-extxyz-by-yuan.zip"
+    mp_elemental_ref_entries = (
+        "mp/2023-02-07-mp-elemental-reference-entries.json.gz",
+        "https://figshare.com/ndownloader/files/40387775",
+    )
+    mp_energies = (
+        "mp/2023-01-10-mp-energies.csv.gz",
+        "https://figshare.com/ndownloader/files/41296875",
+    )
+    mp_patched_phase_diagram = (
+        "mp/2023-02-07-ppd-mp.pkl.gz",
+        "https://figshare.com/ndownloader/files/40344451",
+    )
+    mp_trj_extxyz = (
+        "mp/2023-11-22-mp-trj-extxyz-by-yuan.zip",
+        "https://figshare.com/ndownloader/files/43302033",
+    )
     # snapshot of every task (calculation) in MP as of 2023-03-16 (14 GB)
-    all_mp_tasks = "mp/2023-03-16-all-mp-tasks.zip"
+    all_mp_tasks = (
+        "mp/2023-03-16-all-mp-tasks.zip",
+        "https://figshare.com/ndownloader/files/43350447",
+    )
 
     wbm_computed_structure_entries = (
-        "wbm/2022-10-19-wbm-computed-structure-entries.json.bz2"
+        "wbm/2022-10-19-wbm-computed-structure-entries.json.bz2",
+        "https://figshare.com/ndownloader/files/40344463",
     )
-    wbm_initial_structures = "wbm/2022-10-19-wbm-init-structs.json.bz2"
+    wbm_initial_structures = (
+        "wbm/2022-10-19-wbm-init-structs.json.bz2",
+        "https://figshare.com/ndownloader/files/40344466",
+    )
     wbm_cses_plus_init_structs = (
-        "wbm/2022-10-19-wbm-computed-structure-entries+init-structs.json.bz2"
+        "wbm/2022-10-19-wbm-computed-structure-entries+init-structs.json.bz2",
+        "https://figshare.com/ndownloader/files/40344469",
     )
-    wbm_summary = "wbm/2023-12-13-wbm-summary.csv.gz"
+    wbm_summary = (
+        "wbm/2023-12-13-wbm-summary.csv.gz",
+        "https://figshare.com/ndownloader/files/44225498",
+    )
+    alignn_checkpoint = (
+        "2023-06-02-pbenner-best-alignn-model.pth.zip",
+        "https://figshare.com/ndownloader/files/41233560",
+    )
+    mp_trj = (
+        "mp/2022-09-16-mp-trj-2022-09.json.gz",
+        "https://figshare.com/ndownloader/files/41619375",
+    )
 
-    alignn_checkpoint = "2023-06-02-pbenner-best-alignn-model.pth.zip"
 
-
-# data files can be downloaded and cached with matbench_discovery.data.load()
-DATA_FILES = DataFiles()
-
-
-df_wbm = load("wbm_summary")
+df_wbm = pd.read_csv(DataFiles.wbm_summary.path)
 # str() around Key.mat_id added for https://github.com/janosh/matbench-discovery/issues/81
 df_wbm[str(Key.mat_id)] = df_wbm.index

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -139,6 +139,8 @@ class Files(StrEnum):
                 if is_ipython or sys.stdin.isatty()
                 else "y"
             )
+            if os.getenv("CI"):
+                answer = "n"
             if answer.lower().strip() == "y":
                 if not is_ipython:
                     print(f"Downloading {key!r} from {url} to {abs_path} for caching")

--- a/matbench_discovery/energy.py
+++ b/matbench_discovery/energy.py
@@ -12,7 +12,7 @@ from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.util.typing import EntryLike
 from tqdm import tqdm
 
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 
 
 def get_elemental_ref_entries(
@@ -68,7 +68,7 @@ def get_elemental_ref_entries(
 # contains all MP elemental reference entries to compute formation energies
 # produced by get_elemental_ref_entries() in build_phase_diagram.py
 mp_elem_ref_entries = (
-    pd.read_json(DATA_FILES.mp_elemental_ref_entries, typ="series")
+    pd.read_json(DataFiles.mp_elemental_ref_entries.path, typ="series")
     .map(ComputedEntry.from_dict)
     .to_dict()
 )

--- a/matbench_discovery/preds.py
+++ b/matbench_discovery/preds.py
@@ -17,10 +17,13 @@ __author__ = "Janosh Riebesell"
 __date__ = "2023-02-04"
 
 
-class PredFiles(Files, base=f"{ROOT}/models", key_map=Model.key_val_dict()):
+class PredFiles(Files):
     """Data files provided by Matbench Discovery.
     See https://janosh.github.io/matbench-discovery/contribute for data descriptions.
     """
+
+    base_dir = f"{ROOT}/models"
+    label_map = Model.key_val_dict()
 
     alignn = "alignn/2023-06-02-alignn-wbm-IS2RE.csv.gz"
     # alignn_pretrained = "alignn/2023-06-03-mp-e-form-alignn-wbm-IS2RE.csv.gz"
@@ -105,8 +108,8 @@ def load_df_wbm_with_preds(
     valid_pred_files = {model.name for model in PredFiles}
     if models == ():
         models = tuple(valid_pred_files)
-    inv_map = {v: k for k, v in PredFiles.key_map.items()}
-    models = {inv_map.get(model, model) for model in models}
+    inv_label_map = {v: k for k, v in PredFiles.label_map.items()}  # type: ignore[attr-defined]
+    models = {inv_label_map.get(model, model) for model in models}
     if mismatch := ", ".join(models - valid_pred_files):
         raise ValueError(
             f"Unknown models: {mismatch}, expected subset of {valid_pred_files}"

--- a/matbench_discovery/preds.py
+++ b/matbench_discovery/preds.py
@@ -22,9 +22,6 @@ class PredFiles(Files):
     See https://janosh.github.io/matbench-discovery/contribute for data descriptions.
     """
 
-    base_dir = f"{ROOT}/models"
-    label_map = Model.key_val_dict()
-
     alignn = "alignn/2023-06-02-alignn-wbm-IS2RE.csv.gz"
     # alignn_pretrained = "alignn/2023-06-03-mp-e-form-alignn-wbm-IS2RE.csv.gz"
     # alignn_ff = "alignn_ff/2023-07-11-alignn-ff-wbm-IS2RE.csv.gz"
@@ -75,6 +72,10 @@ class PredFiles(Files):
     # # M3GNet-relaxed structures fed into MEGNet for formation energy prediction
     # m3gnet_megnet = "m3gnet/2022-10-31-m3gnet-wbm-IS2RE.csv.gz"
     # megnet_rs2re = "megnet/2023-08-23-megnet-wbm-RS2RE.csv.gz"
+
+
+PredFiles.base_dir = f"{ROOT}/models"  # type: ignore[attr-defined]
+PredFiles.label_map = Model.key_val_dict()  # type: ignore[attr-defined]
 
 
 def load_df_wbm_with_preds(

--- a/models/alignn/test_alignn.py
+++ b/models/alignn/test_alignn.py
@@ -17,7 +17,7 @@ from sklearn.metrics import r2_score
 from tqdm import tqdm
 
 from matbench_discovery import today
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 from matbench_discovery.slurm import slurm_submit
@@ -30,7 +30,7 @@ module_dir = os.path.dirname(__file__)
 
 # %%
 # model_name = "mp_e_form_alignn"  # pre-trained by NIST (not used for MBD submission)
-model_name = DATA_FILES.alignn_checkpoint  # trained by Philipp Benner
+model_name = DataFiles.alignn_checkpoint.path  # trained by Philipp Benner
 task_type = Task.IS2RE
 target_col = MbdKey.e_form_dft
 input_col = Key.init_struct
@@ -71,8 +71,8 @@ slurm_vars = slurm_submit(
 
 # %% Load data
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
 }[task_type]
 input_col = {Task.IS2RE: Key.init_struct, Task.RS2RE: Key.final_struct}[task_type]
 

--- a/models/alignn/train_alignn.py
+++ b/models/alignn/train_alignn.py
@@ -18,7 +18,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from matbench_discovery import today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.slurm import slurm_submit
 
 __author__ = "Philipp Benner, Janosh Riebesell"
@@ -53,14 +53,16 @@ slurm_vars = slurm_submit(
 
 
 # %% Load data
-df_cse = pd.read_json(DATA_FILES.mp_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.mp_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 df_cse[Key.structure] = [
     Structure.from_dict(cse[Key.structure])
     for cse in tqdm(df_cse.entry, desc="Structures from dict")
 ]
 
 # load energies
-df_in = pd.read_csv(DATA_FILES.mp_energies).set_index(Key.mat_id)
+df_in = pd.read_csv(DataFiles.mp_energies.path).set_index(Key.mat_id)
 df_in[Key.structure] = df_cse[Key.structure]
 if target_col not in df_in:
     raise TypeError(f"{target_col!s} not in {df_in.columns=}")
@@ -74,7 +76,7 @@ df_in[input_col] = [
 
 # %%
 run_params = dict(
-    data_path=DATA_FILES.mp_energies,
+    data_path=DataFiles.mp_energies.path,
     versions={dep: version(dep) for dep in ("alignn", "numpy", "torch", "dgl")},
     model_name=model_name,
     target_col=target_col,

--- a/models/alignn_ff/alignn_ff_relax.py
+++ b/models/alignn_ff/alignn_ff_relax.py
@@ -9,7 +9,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import today
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 
 __author__ = "Janosh Riebesell, Philipp Benner"
@@ -43,8 +43,8 @@ os.makedirs(out_dir, exist_ok=True)
 
 # %% Load data
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
 }[task_type]
 input_col = {Task.IS2RE: Key.init_struct, Task.RS2RE: Key.final_struct}[task_type]
 

--- a/models/alignn_ff/test_alignn_ff.py
+++ b/models/alignn_ff/test_alignn_ff.py
@@ -18,7 +18,7 @@ from sklearn.metrics import r2_score
 from tqdm import tqdm
 
 from matbench_discovery import today
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 
@@ -60,8 +60,8 @@ else:
 
 # %% Load data
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
 }[task_type]
 # load ALIGNN-FF relaxed structures (TODO fix directory we're loading from)
 df_in = pd.concat(map(pd.read_json, glob(f"{module_dir}/data-train-result/*.json.gz")))

--- a/models/bowsr/join_bowsr_results.py
+++ b/models/bowsr/join_bowsr_results.py
@@ -7,7 +7,7 @@ import pymatviz
 from pymatviz.enums import Key
 from tqdm import tqdm
 
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.enums import Model, Task
 
 __author__ = "Janosh Riebesell"
@@ -36,7 +36,7 @@ df_bowsr = pd.concat(dfs.values()).round(4)
 
 
 # %% compare against WBM formation energy targets to make sure we got sensible results
-df_wbm = pd.read_csv(DATA_FILES.wbm_summary).set_index(Key.mat_id)
+df_wbm = pd.read_csv(DataFiles.wbm_summary.path).set_index(Key.mat_id)
 
 
 print(f"{len(df_bowsr) - len(df_wbm)=:,} missing ({len(df_bowsr):,} - {len(df_wbm):,})")

--- a/models/bowsr/test_bowsr.py
+++ b/models/bowsr/test_bowsr.py
@@ -14,7 +14,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import Model, timestamp, today
-from matbench_discovery.data import DATA_FILES, as_dict_handler
+from matbench_discovery.data import DataFiles, as_dict_handler
 from matbench_discovery.enums import Task
 from matbench_discovery.slurm import slurm_submit
 
@@ -39,8 +39,8 @@ job_name = f"bowsr-{energy_model}-wbm-{task_type}"
 out_dir = os.getenv("SBATCH_OUTPUT", f"{module_dir}/{today}-{job_name}")
 
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
 }[task_type]
 
 

--- a/models/cgcnn/test_cgcnn.py
+++ b/models/cgcnn/test_cgcnn.py
@@ -14,7 +14,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from matbench_discovery import CHECKPOINT_DIR, WANDB_PATH, WBM_DIR, today
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 from matbench_discovery.slurm import slurm_submit
@@ -45,8 +45,8 @@ slurm_vars = slurm_submit(
 
 # %%
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
     "IS2RE-debug": f"{WBM_DIR}/2022-10-19-wbm-init-structs.json-1k-samples.bz2",
 }[task_type]
 input_col = {Task.IS2RE: Key.init_struct, Task.RS2RE: Key.final_struct}[task_type]

--- a/models/cgcnn/train_cgcnn.py
+++ b/models/cgcnn/train_cgcnn.py
@@ -13,7 +13,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm, trange
 
 from matbench_discovery import WANDB_PATH, timestamp, today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.slurm import slurm_submit
 from matbench_discovery.structure import perturb_structure
 
@@ -59,10 +59,12 @@ task_type: TaskType = "regression"
 
 
 # %%
-data_path = DATA_FILES.mp_energies
+data_path = DataFiles.mp_energies.path
 df_in = pd.read_csv(data_path).set_index(Key.mat_id)
 
-df_cse = pd.read_json(DATA_FILES.mp_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.mp_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 df_in[input_col] = [Structure.from_dict(cse[input_col]) for cse in tqdm(df_cse.entry)]
 
 if target_col not in df_in:

--- a/models/chgnet/analyze_chgnet.py
+++ b/models/chgnet/analyze_chgnet.py
@@ -13,7 +13,7 @@ from pymatviz.utils import PLOTLY
 
 from matbench_discovery import PDF_FIGS
 from matbench_discovery import plots as plots
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.preds import PRED_FILES, df_preds
 
 __author__ = "Janosh Riebesell"
@@ -68,7 +68,7 @@ fig.show()
 
 
 # %%
-df_cse = pd.read_json(DATA_FILES.wbm_cses_plus_init_structs).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_cses_plus_init_structs.path).set_index(Key.mat_id)
 df_cse.loc[df_diff.index].reset_index().to_json(
     f"{module_dir}/wbm-chgnet-bad-relax.json.gz"
 )

--- a/models/chgnet/analyze_chgnet.py
+++ b/models/chgnet/analyze_chgnet.py
@@ -14,7 +14,7 @@ from pymatviz.utils import PLOTLY
 from matbench_discovery import PDF_FIGS
 from matbench_discovery import plots as plots
 from matbench_discovery.data import DataFiles, df_wbm
-from matbench_discovery.preds import PRED_FILES, df_preds
+from matbench_discovery.preds import PredFiles, df_preds
 
 __author__ = "Janosh Riebesell"
 __date__ = "2023-03-06"
@@ -23,7 +23,7 @@ module_dir = os.path.dirname(__file__)
 
 
 # %%
-df_chgnet = df_chgnet_v030 = pd.read_csv(PRED_FILES.CHGNet)
+df_chgnet = df_chgnet_v030 = pd.read_csv(PredFiles.chgnet.path)
 df_chgnet_v020 = pd.read_csv(
     f"{module_dir}/2023-03-06-chgnet-0.2.0-wbm-IS2RE.csv.gz", index_col=Key.mat_id
 )

--- a/models/chgnet/ctk_structure_viewer.py
+++ b/models/chgnet/ctk_structure_viewer.py
@@ -3,7 +3,7 @@ from crystal_toolkit.helpers.utils import hook_up_fig_with_struct_viewer
 from pymatviz.enums import Key
 from pymatviz.utils import PLOTLY
 
-from matbench_discovery.preds import PRED_FILES
+from matbench_discovery.preds import PredFiles
 
 __author__ = "Janosh Riebesell"
 __date__ = "2023-03-07"
@@ -18,14 +18,14 @@ Then open http://localhost:8000 in your browser.
 e_form_2000 = "e_form_per_atom_chgnet_2000"
 e_form_500 = "e_form_per_atom_chgnet_500"
 
-df_chgnet = pd.read_json(PRED_FILES.CHGNet.replace(".csv.gz", ".json.gz"))
+df_chgnet = pd.read_json(PredFiles.chgnet.path.replace(".csv.gz", ".json.gz"))
 df_chgnet = df_chgnet.set_index(Key.mat_id)
 
-df_chgnet_2000 = pd.read_csv(PRED_FILES.CHGNet)
+df_chgnet_2000 = pd.read_csv(PredFiles.chgnet.path)
 df_chgnet_2000 = df_chgnet_2000.set_index(Key.mat_id).add_suffix("_2000")
 df_chgnet[list(df_chgnet_2000)] = df_chgnet_2000
 
-df_chgnet_500 = pd.read_csv(PRED_FILES.CHGNet.replace("-06", "-04"))
+df_chgnet_500 = pd.read_csv(PredFiles.chgnet.path.replace("-06", "-04"))
 df_chgnet_500 = df_chgnet_500.set_index(Key.mat_id).add_suffix("_500")
 df_chgnet[list(df_chgnet_500)] = df_chgnet_500
 

--- a/models/chgnet/test_chgnet.py
+++ b/models/chgnet/test_chgnet.py
@@ -20,7 +20,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import timestamp, today
-from matbench_discovery.data import DATA_FILES, as_dict_handler, df_wbm
+from matbench_discovery.data import DataFiles, as_dict_handler, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 from matbench_discovery.slurm import slurm_submit
@@ -59,8 +59,8 @@ if os.path.isfile(out_path):
 
 # %%
 data_path = {
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
 }[task_type]
 print(f"\nJob started running {timestamp}")
 print(f"{data_path=}")

--- a/models/m3gnet/join_m3gnet_results.py
+++ b/models/m3gnet/join_m3gnet_results.py
@@ -14,7 +14,7 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatviz.enums import Key
 from tqdm import tqdm
 
-from matbench_discovery.data import DATA_FILES, as_dict_handler
+from matbench_discovery.data import DataFiles, as_dict_handler
 from matbench_discovery.energy import get_e_form_per_atom
 from matbench_discovery.enums import Task
 
@@ -47,7 +47,9 @@ df_m3gnet = pd.concat(dfs.values()).round(4)
 
 
 # %%
-df_cse = pd.read_json(DATA_FILES.wbm_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 df_cse[Key.cse] = [
     ComputedStructureEntry.from_dict(dct) for dct in tqdm(df_cse[Key.cse])
 ]

--- a/models/m3gnet/pre_vs_post_m3gnet_relaxation.py
+++ b/models/m3gnet/pre_vs_post_m3gnet_relaxation.py
@@ -14,7 +14,7 @@ from pymatviz.powerups import add_identity_line
 from sklearn.metrics import r2_score
 
 from matbench_discovery import ROOT, SITE_FIGS, plots
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 
 __author__ = "Janosh Riebesell"
 __date__ = "2022-06-18"
@@ -24,9 +24,9 @@ del plots  # https://github.com/PyCQA/pyflakes/issues/366
 
 
 # %%
-df_wbm = pd.read_json(DATA_FILES.wbm_cses_plus_init_structs).set_index(Key.mat_id)
+df_wbm = pd.read_json(DataFiles.wbm_cses_plus_init_structs.path).set_index(Key.mat_id)
 
-df_summary = pd.read_csv(DATA_FILES.wbm_summary).set_index(Key.mat_id)
+df_summary = pd.read_csv(DataFiles.wbm_summary.path).set_index(Key.mat_id)
 
 
 # %%

--- a/models/m3gnet/test_m3gnet.py
+++ b/models/m3gnet/test_m3gnet.py
@@ -19,7 +19,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import ROOT, timestamp, today
-from matbench_discovery.data import DATA_FILES, as_dict_handler
+from matbench_discovery.data import DataFiles, as_dict_handler
 from matbench_discovery.enums import Task
 from matbench_discovery.slurm import slurm_submit
 
@@ -62,8 +62,8 @@ warnings.filterwarnings(action="ignore", category=UserWarning, module="tensorflo
 
 # %%
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
 }[task_type]
 print(f"\nJob started running {timestamp}")
 print(f"{data_path=}")

--- a/models/mace/analyze_mace.py
+++ b/models/mace/analyze_mace.py
@@ -17,7 +17,7 @@ from matbench_discovery import SITE_FIGS
 from matbench_discovery import plots as plots
 from matbench_discovery.data import df_wbm
 from matbench_discovery.enums import MbdKey
-from matbench_discovery.preds import PRED_FILES
+from matbench_discovery.preds import PredFiles
 
 __author__ = "Janosh Riebesell"
 __date__ = "2023-07-23"
@@ -27,7 +27,7 @@ e_form_mace_col = "e_form_per_atom_mace"
 
 
 # %%
-df_mace = pd.read_csv(PRED_FILES.MACE).set_index(Key.mat_id)
+df_mace = pd.read_csv(PredFiles.mace.path).set_index(Key.mat_id)
 df_mace[list(df_wbm)] = df_wbm
 
 df_mace[Key.spg_num] = df_wbm[MbdKey.init_wyckoff].str.split("_").str[2].astype(int)

--- a/models/mace/join_mace_results.py
+++ b/models/mace/join_mace_results.py
@@ -13,7 +13,7 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatviz.enums import Key
 from tqdm import tqdm
 
-from matbench_discovery.data import DATA_FILES, as_dict_handler, df_wbm
+from matbench_discovery.data import DataFiles, as_dict_handler, df_wbm
 from matbench_discovery.energy import get_e_form_per_atom
 from matbench_discovery.enums import MbdKey, Task
 
@@ -46,7 +46,9 @@ df_mace = pd.concat(dfs.values()).round(4)
 
 
 # %%
-df_cse = pd.read_json(DATA_FILES.wbm_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 
 df_cse[Key.cse] = [
     ComputedStructureEntry.from_dict(dct) for dct in tqdm(df_cse[Key.cse])

--- a/models/mace/json_to_extxyz.py
+++ b/models/mace/json_to_extxyz.py
@@ -13,7 +13,8 @@ from pymatviz.enums import Key
 from pymatviz.io import TqdmDownload
 from tqdm import tqdm
 
-from matbench_discovery import FIGSHARE_URLS, MP_DIR
+from matbench_discovery import MP_DIR
+from matbench_discovery.data import DataFiles
 
 __author__ = "Yuan Chiang"
 __date__ = "2023-08-10"
@@ -23,14 +24,14 @@ mp_trj_path = f"{MP_DIR}/mp-trj-2022-09.json"
 
 
 # %% download MPtrj from figshare (11.3 GB JSON file, can easily take 1h)
-mp_trj_url = FIGSHARE_URLS["mptrj"]["download"]
-
 if os.path.isfile(f"{mp_trj_path}.gz"):
     with gzip.open(f"{mp_trj_path}.gz", "rt") as zip_file:
         json_data = json.load(zip_file)
 else:  # if file not found, download and compress it
-    with TqdmDownload(desc=mp_trj_url) as pbar:
-        urllib.request.urlretrieve(mp_trj_url, mp_trj_path, reporthook=pbar.update_to)
+    with TqdmDownload(desc=DataFiles.mp_trj.url) as pbar:
+        urllib.request.urlretrieve(
+            DataFiles.mp_trj.url, mp_trj_path, reporthook=pbar.update_to
+        )
 
     with open(mp_trj_path) as file:
         json_data = json.load(file)

--- a/models/mace/test_mace.py
+++ b/models/mace/test_mace.py
@@ -18,7 +18,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import ROOT, timestamp, today
-from matbench_discovery.data import DATA_FILES, as_dict_handler, df_wbm
+from matbench_discovery.data import DataFiles, as_dict_handler, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 from matbench_discovery.slurm import slurm_submit
@@ -63,8 +63,8 @@ if os.path.isfile(out_path):
 
 # %%
 data_path = {
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
 }[task_type]
 print(f"\nJob started running {timestamp}")
 print(f"{data_path=}")

--- a/models/mattersim/test_mattersim.py
+++ b/models/mattersim/test_mattersim.py
@@ -139,11 +139,8 @@ def parse_relaxed_atoms_list_as_df(
 
         return mat_id, converged, formation_energy, energy, corrected_energy
 
-    mat_id_list = []
-    cenvergence_list = []
-    e_form_list = []
-    energy_list = []
-    corrected_energy_list = []
+    mat_id_list, converged_list, e_form_list = [], [], []
+    energy_list, corrected_energy_list = [], []
 
     for atoms in tqdm(atoms_list, "Processing relaxed structures"):
         mat_id, converged, formation_energy, energy, corrected_energy = (
@@ -151,16 +148,16 @@ def parse_relaxed_atoms_list_as_df(
         )
         if not keep_unconverged and not converged:
             continue
-        mat_id_list.append(mat_id)
-        cenvergence_list.append(converged)
-        e_form_list.append(formation_energy)
-        energy_list.append(energy)
-        corrected_energy_list.append(corrected_energy)
+        mat_id_list += [mat_id]
+        converged_list += [converged]
+        e_form_list += [formation_energy]
+        energy_list += [energy]
+        corrected_energy_list += [corrected_energy]
 
     return pd.DataFrame(
         {
             Key.mat_id: mat_id_list,
-            "converged": cenvergence_list,
+            "converged": converged_list,
             e_form_col: e_form_list,
             "mattersim_energy": energy_list,
             "corrected_energy": corrected_energy_list,

--- a/models/mattersim/test_mattersim.py
+++ b/models/mattersim/test_mattersim.py
@@ -21,7 +21,7 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from pymatviz.enums import Key
 from tqdm import tqdm
 
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.energy import get_e_form_per_atom
 
 if TYPE_CHECKING:
@@ -107,17 +107,14 @@ def parse_relaxed_atoms_list_as_df(
     e_form_col = "e_form_per_atom_mattersim"
 
     ## Read pre-computed CSEs by WBM
-    df_cse = pd.read_json(DATA_FILES.wbm_computed_structure_entries).set_index(
-        Key.mat_id
-    )
+    wbm_cse_paths = DataFiles.wbm_computed_structure_entries.path
+    df_cse = pd.read_json(wbm_cse_paths).set_index(Key.mat_id)
 
     df_cse[Key.cse] = [
         ComputedStructureEntry.from_dict(dct) for dct in tqdm(df_cse[Key.cse])
     ]
 
-    print(
-        f"Found {len(df_cse):,} CSEs in {DATA_FILES.wbm_computed_structure_entries = }"
-    )
+    print(f"Found {len(df_cse):,} CSEs in {wbm_cse_paths=}")
     print(f"Found {len(atoms_list):,} relaxed structures")
 
     def parse_single_atoms(atoms: ase.Atoms) -> tuple[str, bool, float, float, float]:

--- a/models/megnet/test_megnet.py
+++ b/models/megnet/test_megnet.py
@@ -20,7 +20,7 @@ from sklearn.metrics import r2_score
 from tqdm import tqdm
 
 from matbench_discovery import timestamp, today
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 from matbench_discovery.preds import PRED_FILES
@@ -54,8 +54,8 @@ slurm_vars = slurm_submit(
 # %%
 slurm_array_task_id = int(os.getenv("SLURM_ARRAY_TASK_ID", "0"))
 data_path = {
-    Task.IS2RE: DATA_FILES.wbm_initial_structures,
-    Task.RS2RE: DATA_FILES.wbm_computed_structure_entries,
+    Task.IS2RE: DataFiles.wbm_initial_structures.path,
+    Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
     "chgnet_structure": PRED_FILES.CHGNet.replace(".csv.gz", ".json.gz"),
     "m3gnet_structure": PRED_FILES.M3GNet.replace(".csv.gz", ".json.gz"),
 }[task_type]

--- a/models/megnet/test_megnet.py
+++ b/models/megnet/test_megnet.py
@@ -23,7 +23,7 @@ from matbench_discovery import timestamp, today
 from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
-from matbench_discovery.preds import PRED_FILES
+from matbench_discovery.preds import PredFiles
 from matbench_discovery.slurm import slurm_submit
 
 __author__ = "Janosh Riebesell"
@@ -56,8 +56,8 @@ slurm_array_task_id = int(os.getenv("SLURM_ARRAY_TASK_ID", "0"))
 data_path = {
     Task.IS2RE: DataFiles.wbm_initial_structures.path,
     Task.RS2RE: DataFiles.wbm_computed_structure_entries.path,
-    "chgnet_structure": PRED_FILES.CHGNet.replace(".csv.gz", ".json.gz"),
-    "m3gnet_structure": PRED_FILES.M3GNet.replace(".csv.gz", ".json.gz"),
+    "chgnet_structure": PredFiles.chgnet.path.replace(".csv.gz", ".json.gz"),
+    "m3gnet_structure": PredFiles.m3gnet.path.replace(".csv.gz", ".json.gz"),
 }[task_type]
 print(f"\nJob started running {timestamp}")
 print(f"{data_path=}")
@@ -129,7 +129,9 @@ if task_type != Task.IS2RE:
 
 df_megnet.add_suffix(f"_{task_type.lower()}").round(4).to_csv(out_path)
 
-# df_megnet = pd.read_csv(f"{ROOT}/models/{PRED_FILES.megnet}").set_index(Key.mat_id)
+# df_megnet = pd.read_csv(
+#     f"{ROOT}/models/{PredFiles.megnet.path}"
+# ).set_index(Key.mat_id)
 
 
 # %% compare MEGNet predictions with old and new MP corrections

--- a/models/sevennet/join_results.py
+++ b/models/sevennet/join_results.py
@@ -7,7 +7,7 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatviz.enums import Key
 from tqdm import tqdm
 
-from matbench_discovery.data import DATA_FILES, as_dict_handler, df_wbm
+from matbench_discovery.data import DataFiles, as_dict_handler, df_wbm
 from matbench_discovery.energy import get_e_form_per_atom, mp_elemental_ref_energies
 
 e_form_7net_col = "e_form_per_atom_sevennet"
@@ -28,7 +28,9 @@ df_7net = pd.concat(dfs.values()).round(4)
 if len(df_7net) != len(df_wbm):  # make sure there is no missing structure
     raise ValueError("Missing structures in SevenNet results")
 
-df_cse = pd.read_json(DATA_FILES.wbm_computed_structure_entries).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_computed_structure_entries.path).set_index(
+    Key.mat_id
+)
 df_cse[Key.cse] = [
     ComputedStructureEntry.from_dict(dct) for dct in tqdm(df_cse[Key.cse])
 ]

--- a/models/sevennet/test_sevennet.py
+++ b/models/sevennet/test_sevennet.py
@@ -16,7 +16,7 @@ from sevenn.sevennet_calculator import SevenNetCalculator
 from tqdm import tqdm
 
 from matbench_discovery import timestamp
-from matbench_discovery.data import DATA_FILES, as_dict_handler
+from matbench_discovery.data import DataFiles, as_dict_handler
 from matbench_discovery.enums import Task
 
 __author__ = "Yutack Park"
@@ -57,7 +57,7 @@ slurm_array_task_id = int(os.getenv("SLURM_ARRAY_TASK_ID", "0"))
 os.makedirs(out_dir := "./results", exist_ok=True)
 out_path = f"{out_dir}/{pot_name}-{slurm_array_task_id:>03}.json.gz"
 
-data_path = {Task.IS2RE: DATA_FILES.wbm_initial_structures}[task_type]
+data_path = {Task.IS2RE: DataFiles.wbm_initial_structures.path}[task_type]
 print(f"\nJob started running {timestamp}, eval {pot_name}", flush=True)
 print(f"{data_path=}", flush=True)
 

--- a/models/voronoi_rf/train_test_voronoi_rf.py
+++ b/models/voronoi_rf/train_test_voronoi_rf.py
@@ -14,7 +14,7 @@ from sklearn.metrics import r2_score
 from sklearn.pipeline import Pipeline
 
 from matbench_discovery import ROOT, today
-from matbench_discovery.data import DATA_FILES, df_wbm, glob_to_df
+from matbench_discovery.data import DataFiles, df_wbm, glob_to_df
 from matbench_discovery.enums import MbdKey, Task
 from matbench_discovery.plots import wandb_scatter
 from matbench_discovery.slurm import slurm_submit
@@ -52,7 +52,7 @@ train_path = f"{module_dir}/2022-11-25-features-mp/voronoi-features-mp-*.csv.bz2
 df_train = glob_to_df(train_path).set_index(Key.mat_id)
 print(f"{df_train.shape=}")
 
-df_mp = pd.read_csv(DATA_FILES.mp_energies, na_filter=False).set_index(Key.mat_id)
+df_mp = pd.read_csv(DataFiles.mp_energies.path, na_filter=False).set_index(Key.mat_id)
 
 test_path = f"{module_dir}/2022-11-18-features-wbm-{task_type}.csv.bz2"
 df_test = pd.read_csv(test_path).set_index(Key.mat_id)
@@ -73,7 +73,7 @@ model_name = "Voronoi RandomForestRegressor"
 run_params = dict(
     train_path=train_path,
     test_path=test_path,
-    mp_energies_path=DATA_FILES.mp_energies,
+    mp_energies_path=DataFiles.mp_energies.path,
     versions={dep: version(dep) for dep in ("scikit-learn", "matminer", "numpy")},
     model_name=model_name,
     train_target_col=Key.form_energy,

--- a/models/voronoi_rf/voronoi_featurize_dataset.py
+++ b/models/voronoi_rf/voronoi_featurize_dataset.py
@@ -15,7 +15,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import ROOT, today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.slurm import slurm_submit
 
 sys.path.append(f"{ROOT}/models")
@@ -29,8 +29,8 @@ __date__ = "2022-10-31"
 # %%
 data_name = "mp"
 data_path = {
-    "wbm": DATA_FILES.wbm_initial_structures,
-    "mp": DATA_FILES.mp_computed_structure_entries,
+    "wbm": DataFiles.wbm_initial_structures.path,
+    "mp": DataFiles.mp_computed_structure_entries.path,
 }[data_name]
 
 input_col = Key.init_struct  # or Key.final_struct

--- a/models/wrenformer/analyze_wrenformer.py
+++ b/models/wrenformer/analyze_wrenformer.py
@@ -13,7 +13,7 @@ from pymatviz.ptable import ptable_heatmap_plotly
 from pymatviz.utils import PLOTLY, bin_df_cols
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS, Model
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey
 from matbench_discovery.preds import df_each_pred, df_preds
 
@@ -37,7 +37,7 @@ title = f"{len(df_bad)} {model} preds<br>with {max_each_true=}, {min_each_pred=}
 
 
 # %%
-df_mp = pd.read_csv(DATA_FILES.mp_energies).set_index(Key.mat_id)
+df_mp = pd.read_csv(DataFiles.mp_energies.path).set_index(Key.mat_id)
 df_mp[Key.spg_num] = df_mp[Key.wyckoff].str.split("_").str[2].astype(int)
 df_mp["isopointal_proto_from_aflow"] = df_mp[Key.wyckoff].map(
     get_isopointal_proto_from_aflow

--- a/models/wrenformer/train_wrenformer.py
+++ b/models/wrenformer/train_wrenformer.py
@@ -9,7 +9,7 @@ from aviary.train import df_train_test_split, train_wrenformer
 from pymatviz.enums import Key
 
 from matbench_discovery import WANDB_PATH, timestamp, today
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.slurm import slurm_submit
 
 __author__ = "Janosh Riebesell"
@@ -18,7 +18,7 @@ __date__ = "2022-08-13"
 
 # %%
 epochs = 300
-data_path = DATA_FILES.mp_energies
+data_path = DataFiles.mp_energies.path
 target_col = Key.form_energy
 # data_path = f"{ROOT}/data/2022-08-25-m3gnet-trainset-mp-2021-struct-energy.json.gz"
 # target_col = "mp_energy_per_atom"

--- a/scripts/analyze_model_failure_cases.py
+++ b/scripts/analyze_model_failure_cases.py
@@ -18,7 +18,7 @@ from pymatviz.utils import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS, WBM_DIR
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey
 from matbench_discovery.metrics import classify_stable
 from matbench_discovery.preds import df_each_err, df_each_pred, df_metrics, df_preds
@@ -31,7 +31,7 @@ fp_diff_col = "site_stats_fingerprint_init_final_norm_diff"
 
 
 # %%
-df_cse = pd.read_json(DATA_FILES.wbm_cses_plus_init_structs).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_cses_plus_init_structs.path).set_index(Key.mat_id)
 
 
 # %% plot the highest and lowest error structures before and after relaxation
@@ -143,7 +143,7 @@ fig.show()
 
 
 # %%
-df_mp = pd.read_csv(DATA_FILES.mp_energies, na_filter=False).set_index(Key.mat_id)
+df_mp = pd.read_csv(DataFiles.mp_energies.path, na_filter=False).set_index(Key.mat_id)
 train_count_col = "MP Occurrences"
 df_elem_counts = count_elements(df_mp[Key.formula], count_mode="occurrence").to_frame(
     name=train_count_col

--- a/scripts/compute_struct_fingerprints.py
+++ b/scripts/compute_struct_fingerprints.py
@@ -17,7 +17,7 @@ from pymatviz.utils import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import DATA_DIR, timestamp
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.slurm import slurm_submit
 
 __author__ = "Janosh Riebesell"
@@ -27,8 +27,8 @@ __date__ = "2023-03-26"
 # %% compute all initial and final MP/WBM structure fingerprints
 data_name = "wbm"
 data_path = {
-    "wbm": DATA_FILES.wbm_cses_plus_init_structs,
-    "mp": DATA_FILES.mp_computed_structure_entries,
+    "wbm": DataFiles.wbm_cses_plus_init_structs.path,
+    "mp": DataFiles.mp_computed_structure_entries.path,
 }[data_name]
 
 slurm_array_task_id = int(os.getenv("SLURM_ARRAY_TASK_ID", "0"))

--- a/scripts/model_figs/analyze_model_disagreement.py
+++ b/scripts/model_figs/analyze_model_disagreement.py
@@ -12,7 +12,7 @@ from pymatviz.powerups import add_identity_line
 from pymatviz.utils import PLOTLY
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.enums import MbdKey, TestSubset
 from matbench_discovery.preds import df_preds
 
@@ -89,7 +89,7 @@ for material_cls, pattern in material_classes.items():
 
 
 # %%
-df_cse = pd.read_json(DATA_FILES.wbm_cses_plus_init_structs).set_index(Key.mat_id)
+df_cse = pd.read_json(DataFiles.wbm_cses_plus_init_structs.path).set_index(Key.mat_id)
 
 
 # %% CTK structure viewer

--- a/scripts/model_figs/metrics_tables.py
+++ b/scripts/model_figs/metrics_tables.py
@@ -13,7 +13,7 @@ from pymatviz.utils import si_fmt
 from sklearn.dummy import DummyClassifier
 
 from matbench_discovery import PDF_FIGS, SCRIPTS, SITE_FIGS
-from matbench_discovery.data import DATA_FILES, df_wbm
+from matbench_discovery.data import DataFiles, df_wbm
 from matbench_discovery.enums import MbdKey, Open
 from matbench_discovery.metrics import stable_metrics
 from matbench_discovery.models import MODEL_METADATA
@@ -77,7 +77,7 @@ for model in df_metrics:
 
 
 # %% add dummy classifier results to df_metrics(_10k, _uniq_protos)
-df_mp = pd.read_csv(DATA_FILES.mp_energies, index_col=0)
+df_mp = pd.read_csv(DataFiles.mp_energies.path, index_col=0)
 
 for df_in, df_out, col in (
     (df_wbm, df_metrics, "Dummy"),

--- a/scripts/project_compositions.py
+++ b/scripts/project_compositions.py
@@ -12,7 +12,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import DATA_DIR
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 from matbench_discovery.slurm import slurm_submit
 
 __author__ = "Janosh Riebesell"
@@ -34,7 +34,9 @@ slurm_vars = slurm_submit(
     time="6:0:0",
 )
 
-data_path = {"wbm": DATA_FILES.wbm_summary, "mp": DATA_FILES.mp_energies}[data_name]
+data_path = {"wbm": DataFiles.wbm_summary.path, "mp": DataFiles.mp_energies.path}[
+    data_name
+]
 print(f"{data_path=}")
 print(f"{out_dim=}")
 print(f"{projection_type=}")

--- a/scripts/upload_to_figshare.py
+++ b/scripts/upload_to_figshare.py
@@ -17,7 +17,7 @@ from requests.exceptions import HTTPError
 from tqdm import tqdm
 
 from matbench_discovery import DATA_DIR, FIGSHARE_DIR, ROOT
-from matbench_discovery.data import DATA_FILES, DataFiles
+from matbench_discovery.data import DataFiles
 
 __author__ = "Janosh Riebesell"
 __date__ = "2023-04-27"
@@ -134,10 +134,10 @@ def main(pyproject: dict[str, Any], urls_json_path: str) -> int:
     try:
         article_id = create_article(metadata)
         uploaded_files: dict[str, tuple[str, str]] = {}
-        pbar = tqdm(DATA_FILES, desc="Uploading to Figshare")
+        pbar = tqdm(DataFiles, desc="Uploading to Figshare")
         for key in pbar:
             pbar.set_postfix(file=key)
-            file_path = f"{DATA_DIR}/{DataFiles.__dict__[key]}"
+            file_path = f"{DATA_DIR}/{key.rel_path}"
             file_id = upload_file_to_figshare(article_id, file_path)
             file_url = f"https://figshare.com/ndownloader/files/{file_id}"
             uploaded_files[key] = (file_url, file_path.split("/")[-1])

--- a/scripts/wbm_umap_projection.py
+++ b/scripts/wbm_umap_projection.py
@@ -22,7 +22,7 @@ from pymatviz.io import save_fig
 from tqdm import tqdm
 
 from matbench_discovery import MP_DIR, PDF_FIGS, WBM_DIR
-from matbench_discovery.data import DATA_FILES
+from matbench_discovery.data import DataFiles
 
 __author__ = "Philipp Benner, Janosh Riebesell"
 __date__ = "2023-11-28"
@@ -140,12 +140,12 @@ def features_to_drop(df_in: pd.DataFrame, threshold: float = 0.95) -> list[str]:
 # %% Compute matminer features for MP and WBM, then export to CSV
 if not os.path.isfile(mp_matminer_feat_path):
     df_mp_feats = featurize_file(
-        DATA_FILES.mp_computed_structure_entries, struct_col="entry"
+        DataFiles.mp_computed_structure_entries.path, struct_col="entry"
     )
     df_mp_feats.to_csv(mp_matminer_feat_path)
 
 if not os.path.isfile(wbm_matminer_feat_path):
-    df_wbm_feats = featurize_file(DATA_FILES.wbm_initial_structures)
+    df_wbm_feats = featurize_file(DataFiles.wbm_initial_structures.path)
     df_wbm_feats.to_csv(wbm_matminer_feat_path)
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,25 +1,20 @@
 import json
 import os
 from pathlib import Path
-from random import random
 from typing import Any
-from unittest.mock import patch
 
 import pandas as pd
 import pytest
 from pymatgen.core import Lattice, Structure
 from pymatviz.enums import Key
 
-from matbench_discovery import FIGSHARE_DIR, ROOT
+from matbench_discovery import FIGSHARE_DIR
 from matbench_discovery.data import (
-    DATA_FILES,
     as_dict_handler,
     df_wbm,
     figshare_versions,
     glob_to_df,
-    load,
 )
-from matbench_discovery.enums import MbdKey
 
 with open(f"{FIGSHARE_DIR}/{figshare_versions[-1]}.json") as file:
     figshare_urls = json.load(file)["files"]
@@ -29,155 +24,6 @@ structure = Structure(
     species=("Fe", "O"),
     coords=((0, 0, 0), (0.5, 0.5, 0.5)),
 )
-
-
-@pytest.mark.parametrize(
-    "key, hydrate",
-    [
-        ("wbm_summary", True),
-        ("wbm_initial_structures", True),
-        ("wbm_computed_structure_entries", False),
-        ("mp_elemental_ref_entries", True),
-        ("mp_energies", True),
-    ],
-)
-def test_load(
-    df_float: pd.DataFrame,
-    # df with Structures and ComputedStructureEntries as dicts
-    df_with_pmg_objects: pd.DataFrame,
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-    key: str,
-    hydrate: bool,
-) -> None:
-    filepath = DATA_FILES[key]
-    # intercept HTTP requests and write dummy df to disk instead
-    with patch("urllib.request.urlretrieve") as url_retrieve:
-        writer = df_with_pmg_objects.to_json if ".json" in filepath else df_float.to_csv
-        url_retrieve.side_effect = lambda _url, path: writer(path)
-        out = load(
-            key,
-            hydrate=hydrate,
-            # test both str and Path for cache_dir
-            cache_dir=str(tmp_path) if random() < 0.5 else tmp_path,
-        )
-
-    stdout, _stderr = capsys.readouterr()
-
-    assert f"Downloading {key!r} from {figshare_urls[key][0]}" in stdout
-
-    # check we called read_csv/read_json once for each data_name
-    assert url_retrieve.call_count == 1
-
-    assert isinstance(out, pd.DataFrame), f"{key} not a DataFrame"
-
-    # test that df loaded from cache is the same as initial df
-    from_cache = load(key, hydrate=hydrate, cache_dir=tmp_path)
-    pd.testing.assert_frame_equal(out, from_cache)
-
-
-def test_load_raises(tmp_path: Path) -> None:
-    key = "bad-key"
-    with pytest.raises(ValueError) as exc:  # noqa: PT011
-        load(key)
-
-    assert f"Unknown {key=}, must be one of {list(DATA_FILES)}" in str(exc.value)
-
-    version = "invalid-version"
-    with pytest.raises(ValueError) as exc:  # noqa: PT011
-        load("wbm_summary", version=version, cache_dir=tmp_path)
-
-    assert (
-        str(exc.value) == f"Unexpected {version=}. Must be one of {figshare_versions}."
-    )
-    assert os.listdir(tmp_path) == [], "cache_dir should be empty"
-
-
-def test_load_doc_str() -> None:
-    doc_str = load.__doc__
-    assert isinstance(doc_str, str)  # mypy type narrowing
-
-    # check that we link to the right data description page
-    with open(f"{ROOT}/site/package.json") as file:
-        pkg = json.load(file)  # get repo URL from package.json
-    route = "/contribute"
-    assert f"{pkg['homepage']}/contribute" in doc_str
-    assert os.path.isdir(f"{ROOT}/site/src/routes/{route}")
-
-
-wbm_summary_expected_cols = {
-    "uncorrected_energy_from_cse",
-    Key.bandgap_pbe,
-    MbdKey.dft_energy,
-    MbdKey.e_form_raw,
-    MbdKey.e_form_wbm,
-    MbdKey.e_form_dft,
-    MbdKey.each_wbm,
-    Key.formula,
-    Key.n_sites,
-    Key.volume,
-    Key.wyckoff,
-}
-
-
-# TODO skip this test if offline
-# @pytest.mark.skipif(online, reason="requires internet connection")
-@pytest.mark.parametrize(
-    "file_key, version, expected_shape, expected_cols",
-    [
-        ("mp_elemental_ref_entries", figshare_versions[-1], (9, 89), set()),
-        pytest.param(
-            "wbm_summary",
-            figshare_versions[-1],
-            (256_963, 17),
-            wbm_summary_expected_cols,
-            marks=pytest.mark.slow,  # run pytest -m 'slow' to select this marker
-        ),
-        pytest.param(
-            # large file but needed to test loading compressed JSON from URL
-            "mp_computed_structure_entries",
-            figshare_versions[-1],
-            (154_718, 1),
-            {"entry"},
-            marks=pytest.mark.very_slow,
-        ),
-    ],
-)
-def test_load_no_mock(
-    file_key: str,
-    version: str,
-    expected_shape: tuple[int, int],
-    expected_cols: set[str],
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-) -> None:
-    assert os.listdir(tmp_path) == [], "cache_dir should be empty"
-    # This function runs the download from Figshare for real hence takes some time and
-    # requires being online
-    df_out = load(file_key, version=version, cache_dir=tmp_path)
-    assert len(os.listdir(tmp_path)) == 1, "cache_dir should have one file"
-    assert df_out.shape == expected_shape
-    assert (
-        set(df_out) >= expected_cols
-    ), f"Loaded df missing columns {expected_cols - set(df_out)}"
-
-    stdout, stderr = capsys.readouterr()
-    assert stderr == ""
-    rel_path = getattr(type(DATA_FILES), file_key)
-    cache_path = f"{tmp_path}/{rel_path}"
-    assert (
-        f"Downloading {file_key!r} from {figshare_urls[file_key][0]}\nCached "
-        f"{file_key!r} to {cache_path!r}" in stdout
-    )
-
-    # test that df loaded from cache is the same as initial df
-    pd.testing.assert_frame_equal(
-        df_out, load(file_key, version=version, cache_dir=tmp_path)
-    )
-
-    stdout, stderr = capsys.readouterr()
-    assert stderr == ""
-    assert stdout == f"Loading {file_key!r} from cached file at {cache_path!r}\n"
 
 
 def test_as_dict_handler() -> None:

--- a/tests/test_preds.py
+++ b/tests/test_preds.py
@@ -6,7 +6,7 @@ from pymatviz.enums import Key
 from matbench_discovery.data import df_wbm
 from matbench_discovery.enums import MbdKey
 from matbench_discovery.preds import (
-    PRED_FILES,
+    PredFiles,
     df_each_err,
     df_each_pred,
     df_metrics,
@@ -20,7 +20,8 @@ def test_df_wbm() -> None:
 
 
 def test_df_metrics() -> None:
-    assert {*df_metrics} >= {*PRED_FILES}
+    missing_cols = {*df_metrics} - {model.name for model in PredFiles}
+    assert missing_cols == set(), f"{missing_cols=}"
     assert df_metrics.T.MAE.between(0, 0.2).all(), f"unexpected {df_metrics.T.MAE=}"
     assert df_metrics.T.R2.between(-1.5, 1).all(), f"unexpected {df_metrics.T.R2=}"
     assert df_metrics.T.RMSE.between(0, 0.3).all(), f"unexpected {df_metrics.T.RMSE=}"
@@ -65,11 +66,12 @@ def test_load_df_wbm_with_preds_raises() -> None:
 
 
 def test_pred_files() -> None:
-    assert len(PRED_FILES) >= 6
+    assert len(PredFiles) >= 6
     assert all(
-        path.endswith((".csv", ".csv.gz", ".json", ".json.gz"))
-        for path in PRED_FILES.values()
+        file.path.endswith((".csv", ".csv.gz", ".json", ".json.gz"))
+        for file in PredFiles
     )
-    for model, path in PRED_FILES.items():
+    for model in PredFiles:
+        path = model.path
         msg = f"Missing preds file for {model=}, expected at {path=}"
         assert os.path.isfile(path), msg

--- a/tests/test_preds.py
+++ b/tests/test_preds.py
@@ -20,7 +20,7 @@ def test_df_wbm() -> None:
 
 
 def test_df_metrics() -> None:
-    missing_cols = {*df_metrics} - {model.name for model in PredFiles}
+    missing_cols = {*df_metrics} - {model.label for model in PredFiles}
     assert missing_cols == set(), f"{missing_cols=}"
     assert df_metrics.T.MAE.between(0, 0.2).all(), f"unexpected {df_metrics.T.MAE=}"
     assert df_metrics.T.R2.between(-1.5, 1).all(), f"unexpected {df_metrics.T.R2=}"


### PR DESCRIPTION
goal of this PR is to improve developer experience. `Files` and its subclasses were opaque (e.g. `PredFiles.mace` and `PredFiles.MACE` were different paths [relative and absolute, resp.]) and awkward before. they were used as singletons (see now removed `PRED_FILES` and `DATA_FILES`) but this was in no way enforced by the code whereas now comes for free with via `StrEnum`