### PR TITLE
Correct batch_size of SevenNet-0

### DIFF
--- a/models/sevennet/sevennet.yml
+++ b/models/sevennet/sevennet.yml
@@ -45,7 +45,7 @@ hyperparams:
   optimizer: Adam
   loss: Huber - delta=0.01
   loss_weights: { energy: 1.0, force: 1.0, stress: 0.01 }
-  batch_size: 128 # 32 (gpus) * 4 (batch per gpu) = 128 (total batch size)
+  batch_size: 4096 # 32 (gpus) * 128 (batch per gpu) = 4096 (total batch size)
   initial_learning_rate: 0.010
   learning_rate_schedule: LinearLR - start_factor=1.0, total_iters=600, end_factor=0.0001
   epochs: 600

--- a/models/sevennet/train_sevennet/pre_train.yaml
+++ b/models/sevennet/train_sevennet/pre_train.yaml
@@ -63,7 +63,7 @@ train:
   #    reset_scheduler: False
 data:
   data_shuffle: False
-  batch_size: 4 # batch size per gpu
+  batch_size: 128  # per GPU batch size, as the model trained with 32 GPUs, the effective batch size equals 4096.
   scale: per_atom_energy_std
   shift: elemwise_reference_energies
 

--- a/models/sevennet/train_sevennet/pre_train.yaml
+++ b/models/sevennet/train_sevennet/pre_train.yaml
@@ -63,7 +63,7 @@ train:
   #    reset_scheduler: False
 data:
   data_shuffle: False
-  batch_size: 128  # per GPU batch size, as the model trained with 32 GPUs, the effective batch size equals 4096.
+  batch_size: 128 # per GPU batch size, as the model trained with 32 GPUs, the effective batch size equals 4096.
   scale: per_atom_energy_std
   shift: elemwise_reference_energies
 


### PR DESCRIPTION
I was confused about `batch_size` and wrote the incorrect value. This pull request is to correct this.

The correct batch size to reproduce SevenNet-0 is 4096(with 32 GPUs and 128 per gpu batch size). Sorry for the mistake.