### PR TITLE
Fix markdown to HTML conversion of model notes

### DIFF
--- a/data/training-sets.yml
+++ b/data/training-sets.yml
@@ -30,6 +30,8 @@ MatterSim:
   title: MatterSim
   url: https://doi.org/10.48550/arXiv.2405.04967
   n_structures: 17_000_000
+  temperature_range: 0-5000 K
+  pressure_range: 0-1000 GPa
 
 Alex:
   title: Alexandria

--- a/data/wbm/eda_wbm.py
+++ b/data/wbm/eda_wbm.py
@@ -12,7 +12,8 @@ import pymatviz as pmv
 from matplotlib.colors import SymLogNorm
 from pymatgen.core import Composition, Structure
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY, si_fmt_int
+from pymatviz.typing import PLOTLY
+from pymatviz.utils import si_fmt_int
 
 from matbench_discovery import PDF_FIGS, ROOT, SITE_FIGS, STABILITY_THRESHOLD
 from matbench_discovery import plots as plots

--- a/matbench_discovery/plots.py
+++ b/matbench_discovery/plots.py
@@ -16,7 +16,7 @@ import scipy.stats
 import wandb
 from plotly.validators.scatter.line import DashValidator
 from plotly.validators.scatter.marker import SymbolValidator
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import STABILITY_THRESHOLD

--- a/matbench_discovery/preds/geo_opt.py
+++ b/matbench_discovery/preds/geo_opt.py
@@ -36,7 +36,7 @@ else:
         geo_opt_metrics = model_metadata.get("metrics", {}).get("geo_opt", {})
         if geo_opt_metrics in ("not applicable", "not available"):
             continue
-        ml_relaxed_structs_path = f"{ROOT}/{geo_opt_metrics.get("pred_file")}"
+        ml_relaxed_structs_path = f"{ROOT}/{geo_opt_metrics.get('pred_file')}"
         if not ml_relaxed_structs_path:
             continue
         if not os.path.isfile(ml_relaxed_structs_path):

--- a/models/chgnet/ctk_structure_viewer.py
+++ b/models/chgnet/ctk_structure_viewer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from crystal_toolkit.helpers.utils import hook_up_fig_with_struct_viewer
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 
 from matbench_discovery.data import Model
 

--- a/models/mattersim/mattersim.yml
+++ b/models/mattersim/mattersim.yml
@@ -103,18 +103,15 @@ hyperparams:
 
 notes:
   Description: Graphormer is a general-purpose deep learning backbone for molecular modeling.
-  Training:
-    desc: MatterSim was trained on a large, closed dataset covering diverse combinations of 89 elements across many temperature and pressure.
-    temperature_range: 0-5000 K
-    pressure_range: 0-1000 GPa
-  Tested Applications:
+  Training: MatterSim was trained on a large, closed dataset covering diverse combinations of 89 elements across many temperatures and pressures.
+  Tested Applications: |
     - Energy, force, stress prediction
     - Molecular dynamics simulations
     - Phonons
     - Mechanical properties
     - Free energy and phase diagrams
     - Materials discovery
-  Training Data Sources:
+  Training Data Sources: |
     - Materials Project
     - Alexandria dataset
     - newly generated structures and MD trajectories

--- a/models/wrenformer/analyze_wrenformer.py
+++ b/models/wrenformer/analyze_wrenformer.py
@@ -10,7 +10,8 @@ from pymatviz.enums import Key
 from pymatviz.io import df_to_html, df_to_pdf, save_fig
 from pymatviz.powerups import add_identity_line
 from pymatviz.ptable import ptable_heatmap_plotly
-from pymatviz.utils import PLOTLY, bin_df_cols
+from pymatviz.typing import PLOTLY
+from pymatviz.utils import bin_df_cols
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS
 from matbench_discovery.data import DataFiles, Model, df_wbm

--- a/scripts/analyze_model_failure_cases.py
+++ b/scripts/analyze_model_failure_cases.py
@@ -13,7 +13,7 @@ import plotly.graph_objs as go
 import pymatviz as pmv
 from pymatgen.core import Composition, Structure
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS, WBM_DIR

--- a/scripts/calc_model_run_times.py
+++ b/scripts/calc_model_run_times.py
@@ -13,7 +13,7 @@ import pymatviz as pmv
 import requests
 import wandb
 import wandb.apis.public
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import SITE_FIGS, WANDB_PATH

--- a/scripts/compute_struct_fingerprints.py
+++ b/scripts/compute_struct_fingerprints.py
@@ -13,7 +13,7 @@ from matminer.featurizers.site import CrystalNNFingerprint
 from matminer.featurizers.structure import SiteStatsFingerprint
 from pymatgen.core import Structure
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 from tqdm import tqdm
 
 from matbench_discovery import DATA_DIR, timestamp

--- a/scripts/model_figs/analyze_model_disagreement.py
+++ b/scripts/model_figs/analyze_model_disagreement.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pymatviz as pmv
 from pymatviz.enums import Key
 from pymatviz.powerups import add_identity_line
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS
 from matbench_discovery.enums import MbdKey, TestSubset

--- a/scripts/model_figs/roc_curves_models.py
+++ b/scripts/model_figs/roc_curves_models.py
@@ -6,7 +6,7 @@ import math
 import pandas as pd
 import pymatviz as pmv
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 from sklearn.metrics import auc, roc_curve
 from tqdm import tqdm
 

--- a/scripts/model_figs/tiles_prc_curves_models.py
+++ b/scripts/model_figs/tiles_prc_curves_models.py
@@ -6,7 +6,7 @@ import math
 import pandas as pd
 import pymatviz as pmv
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY
+from pymatviz.typing import PLOTLY
 from sklearn.metrics import precision_recall_curve
 from tqdm import tqdm
 

--- a/scripts/per_element_errors.py
+++ b/scripts/per_element_errors.py
@@ -9,7 +9,8 @@ import plotly.express as px
 import pymatviz as pmv
 from pymatgen.core import Composition, Element
 from pymatviz.enums import Key
-from pymatviz.utils import PLOTLY, bin_df_cols, df_ptable, si_fmt
+from pymatviz.typing import PLOTLY
+from pymatviz.utils import bin_df_cols, df_ptable, si_fmt
 from tqdm import tqdm
 
 from matbench_discovery import PDF_FIGS, ROOT, SITE_FIGS

--- a/site/src/lib/HeatmapTable.svelte
+++ b/site/src/lib/HeatmapTable.svelte
@@ -18,7 +18,7 @@
   export let hide_cols: string[] = [] // just the column labels
   export let format: Record<string, string> = {}
   // set to empty string to hide hint
-  export let sort_hint: string = `Click on numerical column headers to sort the table rows by their values`
+  export let sort_hint: string = `Click on column headers to sort table rows`
   export let style: string | null = null
 
   const sort_state = writable({ column: ``, ascending: true })
@@ -109,6 +109,8 @@
             >
               {#if typeof val === `number` && format[label]}
                 {@html pretty_num(val, format[label])}
+              {:else if [undefined, null].includes(val)}
+                <span title="not available">n/a</span>
               {:else}
                 {@html val}
               {/if}

--- a/site/src/lib/ModelCard.svelte
+++ b/site/src/lib/ModelCard.svelte
@@ -81,9 +81,9 @@
       {pretty_num(missing_preds, `,.0f`)}
       <small>({missing_percent})</small>
     {/if}
-    {#if notes?.missing_preds}
+    {#if notes.html?.missing_preds}
       <Tooltip
-        text={notes.missing_preds ?? ``}
+        text={notes.html.missing_preds ?? ``}
         tip_style="font-size: 9pt;"
         max_width="20em"
         min_width="20em"

--- a/site/src/lib/model-schema.d.ts
+++ b/site/src/lib/model-schema.d.ts
@@ -64,12 +64,11 @@ export interface ModelMetadata {
   }
   notes?: {
     Description?: string
-    Training?:
-      | string
-      | {
-          [k: string]: string
-        }
+    Training?: string
     'Missing Preds'?: string
+    html?: {
+      [k: string]: unknown
+    }
     [k: string]: unknown
   }
   model_params: number

--- a/site/src/routes/models/[slug]/+page.svelte
+++ b/site/src/routes/models/[slug]/+page.svelte
@@ -268,9 +268,9 @@
       </section>
     {/if}
 
-    {#if model.notes}
+    {#if model.notes?.html}
       <section class="notes">
-        {#each Object.entries(model.notes) as [key, note]}
+        {#each Object.entries(model.notes.html) as [key, note]}
           <h2>{key}</h2>
           {#if typeof note === `string`}
             <p>{@html note}</p>

--- a/tests/model-schema.yml
+++ b/tests/model-schema.yml
@@ -93,13 +93,12 @@ properties:
       Description:
         type: string
       Training:
-        oneOf:
-          - type: string
-          - type: object
-            additionalProperties:
-              type: string
+        type: string
       Missing Preds:
         type: string
+      html:
+        type: object
+        additionalProperties: true
     additionalProperties: true
   model_params:
     type: number


### PR DESCRIPTION
markdown model notes in YAML files now parsed to nested `notes.html` attribute object

no longer overwrites markdown with HTML which failed if the note parsed again