### PR TITLE
Upload model relaxed-structures and energy predictions to Figshare

### DIFF
--- a/matbench_discovery/figshare.py
+++ b/matbench_discovery/figshare.py
@@ -11,11 +11,14 @@ from tqdm import tqdm
 
 from matbench_discovery import ROOT
 
-with open(f"{ROOT}/site/.env") as file:
-    # TOKEN: length 128, alphanumeric (e.g. 271431c6a94ff7...)
-    TOKEN = file.read().split("figshare_token=")[1].split("\n")[0]
-
+ENV_PATH = f"{ROOT}/site/.env"
 BASE_URL = "https://api.figshare.com/v2"
+
+FIGSHARE_TOKEN = os.getenv("FIGSHARE_TOKEN")
+if not FIGSHARE_TOKEN and os.path.isfile(ENV_PATH):
+    with open(ENV_PATH) as file:
+        # TOKEN: length 128, alphanumeric (e.g. 271431c6a94ff7...)
+        FIGSHARE_TOKEN = file.read().split("figshare_token=")[1].split("\n")[0]
 
 
 def make_request(
@@ -35,7 +38,7 @@ def make_request(
     Raises:
         HTTPError: If the request fails. Error will contain the response body.
     """
-    headers = {"Authorization": f"token {TOKEN}"}
+    headers = {"Authorization": f"token {FIGSHARE_TOKEN}"}
     if data is not None and not binary:
         data = json.dumps(data)
     response = requests.request(method, url, headers=headers, data=data, timeout=10)

--- a/matbench_discovery/figshare.py
+++ b/matbench_discovery/figshare.py
@@ -1,0 +1,123 @@
+"""Helper functions for uploading files to Figshare via their API."""
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import requests
+from tqdm import tqdm
+
+from matbench_discovery import ROOT
+
+with open(f"{ROOT}/site/.env") as file:
+    # TOKEN: length 128, alphanumeric (e.g. 271431c6a94ff7...)
+    TOKEN = file.read().split("figshare_token=")[1].split("\n")[0]
+
+BASE_URL = "https://api.figshare.com/v2"
+
+
+def make_request(
+    method: str, url: str, *, data: Any = None, binary: bool = False
+) -> Any:
+    """Make a token-authorized HTTP request to the Figshare API.
+
+    Args:
+        method (str): HTTP method (GET, POST, PUT, DELETE).
+        url (str): URL to send the request to.
+        data (Any, optional): Data to send in the request body. Defaults to None.
+        binary (bool, optional): Whether the data is binary. Defaults to False.
+
+    Returns:
+        Any: JSON response data or binary data.
+
+    Raises:
+        HTTPError: If the request fails. Error will contain the response body.
+    """
+    headers = {"Authorization": f"token {TOKEN}"}
+    if data is not None and not binary:
+        data = json.dumps(data)
+    response = requests.request(method, url, headers=headers, data=data, timeout=10)
+    try:
+        response.raise_for_status()
+        try:
+            data = json.loads(response.content)
+        except ValueError:
+            data = response.content
+    except requests.HTTPError as exc:
+        exc.add_note(f"body={response.content.decode()}")
+        raise
+
+    return data
+
+
+def create_article(metadata: Mapping[str, Sequence[object]]) -> int:
+    """Create a new Figshare article with given metadata and return the article ID.
+
+    Args:
+        metadata (dict): Article metadata including title, description, etc.
+
+    Returns:
+        int: The ID of the created article.
+    """
+    result = make_request("POST", f"{BASE_URL}/account/articles", data=metadata)
+    print(f"Created article: {result['location']} with title {metadata['title']}\n")
+    result = make_request("GET", result["location"])
+    return result["id"]
+
+
+def get_file_hash_and_size(
+    file_name: str, chunk_size: int = 10_000_000
+) -> tuple[str, int]:
+    """Get the md5 hash and size of a file.
+
+    Args:
+        file_name (str): Path to the file.
+        chunk_size (int, optional): Size of chunks to read. Defaults to 10MB.
+
+    Returns:
+        tuple[str, int]: MD5 hash and file size in bytes.
+    """
+    md5 = hashlib.md5()  # noqa: S324
+    size = 0
+    with open(file_name, mode="rb") as file:
+        while data := file.read(chunk_size):
+            size += len(data)
+            md5.update(data)
+    return md5.hexdigest(), size
+
+
+def upload_file_to_figshare(article_id: int, file_path: str) -> int:
+    """Upload a file to Figshare and return the file ID.
+
+    Args:
+        article_id (int): ID of the article to upload to.
+        file_path (str): Path to the file to upload.
+
+    Returns:
+        int: The ID of the uploaded file.
+    """
+    # Initiate new upload
+    md5, size = get_file_hash_and_size(file_path)
+    data = dict(name=os.path.basename(file_path), md5=md5, size=size)
+    endpoint = f"{BASE_URL}/account/articles/{article_id}/files"
+    result = make_request("POST", endpoint, data=data)
+    file_info = make_request("GET", result["location"])
+
+    # Upload parts
+    url = file_info["upload_url"]
+    result = make_request("GET", url)
+    with open(file_path, mode="rb") as file:
+        for part in tqdm(result["parts"], desc=file_path):
+            # Upload part
+            u_data = file_info.copy()
+            u_data.update(part)
+            url = f"{u_data['upload_url']}/{part['partNo']}"
+            file.seek(part["startOffset"])
+            chunk = file.read(part["endOffset"] - part["startOffset"] + 1)
+            make_request("PUT", url, data=chunk, binary=True)
+
+    # Complete upload
+    make_request("POST", f"{endpoint}/{file_info['id']}")
+    return file_info["id"]

--- a/matbench_discovery/geo-opt-files.yml
+++ b/matbench_discovery/geo-opt-files.yml
@@ -1,0 +1,11 @@
+eqV2-31M-dens-mp-p5.json.gz: https://figshare.com/ndownloader/files/51606407
+eqV2-86M-omat-salex-mp.json.gz: https://figshare.com/ndownloader/files/51606410
+GRACE_2L_r6_11Nov2024_relaxed_structures.json.gz: https://figshare.com/ndownloader/files/51606452
+2023-01-23-bowsr-megnet-wbm-IS2RE.json.gz: https://figshare.com/ndownloader/files/51606467
+2023-06-01-m3gnet-manual-sampling-wbm-IS2RE.json.gz: https://figshare.com/ndownloader/files/51606473
+2023-12-21-chgnet-0.3.0-wbm-IS2RE.json.gz: https://figshare.com/ndownloader/files/51606521
+orb-mptrj-only-v2-20241014.json.gz: https://figshare.com/ndownloader/files/51606536
+orb-v2-20241011.json.gz: https://figshare.com/ndownloader/files/51606542
+2024-07-11-sevennet-0-relaxed-structures.json.gz: https://figshare.com/ndownloader/files/51606617
+sevennet-l3i5-structures.json.gz: https://figshare.com/ndownloader/files/51606623
+article: https://figshare.com/articles/dataset/22715158

--- a/models/alignn/alignn.yml
+++ b/models/alignn/alignn.yml
@@ -51,6 +51,7 @@ metrics:
   geo_opt: not available
   discovery:
     pred_file: models/alignn/2023-06-02-alignn-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607262
     pred_col: e_form_per_atom_alignn
     full_test_set:
       F1: 0.565 # fraction

--- a/models/alignn_ff/alignn-ff.yml
+++ b/models/alignn_ff/alignn-ff.yml
@@ -62,4 +62,5 @@ metrics:
   geo_opt: not available
   discovery:
     pred_file: models/alignn_ff/2023-07-11-alignn-ff-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607187
     pred_col: e_form_per_atom_alignn_ff

--- a/models/bowsr/bowsr.yml
+++ b/models/bowsr/bowsr.yml
@@ -61,6 +61,7 @@ metrics:
   phonons: not applicable # model doesn't predict forces
   geo_opt:
     pred_file: models/bowsr/2023-01-23-bowsr-megnet-wbm-IS2RE.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607409
     pred_col: structure_bowsr_megnet
     symprec=1e-5:
       rmsd: 0.043 # Å
@@ -78,6 +79,7 @@ metrics:
       n_structures: 250430 # count
   discovery:
     pred_file: models/bowsr/2023-01-23-bowsr-megnet-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607265
     pred_col: e_form_per_atom_bowsr_megnet
     full_test_set:
       F1: 0.437 # fraction

--- a/models/cgcnn/cgcnn+p.yml
+++ b/models/cgcnn/cgcnn+p.yml
@@ -54,6 +54,7 @@ metrics:
   geo_opt: not applicable
   discovery:
     pred_file: models/cgcnn/2023-02-05-cgcnn-perturb=5-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607274
     pred_col: e_form_per_atom_cgcnn_pred_ens
     full_test_set:
       F1: 0.51 # fraction

--- a/models/cgcnn/cgcnn.yml
+++ b/models/cgcnn/cgcnn.yml
@@ -48,6 +48,7 @@ metrics:
   geo_opt: not applicable
   discovery:
     pred_file: models/cgcnn/2023-01-26-cgcnn-ens=10-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607271
     pred_col: e_form_per_atom_mp2020_corrected_pred_ens
     full_test_set:
       F1: 0.51 # fraction

--- a/models/chgnet/chgnet.yml
+++ b/models/chgnet/chgnet.yml
@@ -68,6 +68,7 @@ metrics:
     κ_SRME: 1.717
   geo_opt:
     pred_file: models/chgnet/2023-12-21-chgnet-0.3.0-wbm-IS2RE.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607412
     pred_col: chgnet_structure
     symprec=1e-5:
       rmsd: 0.0216 # Å
@@ -85,6 +86,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/chgnet/2023-12-21-chgnet-0.3.0-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607268
     pred_col: e_form_per_atom_chgnet
     full_test_set:
       F1: 0.612 # fraction

--- a/models/eqV2/eqV2-m-omat-mp-salex.yml
+++ b/models/eqV2/eqV2-m-omat-mp-salex.yml
@@ -87,6 +87,7 @@ notes:
 metrics:
   geo_opt:
     pred_file: models/eqV2/eqV2-86M-omat-salex-mp.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607436
     pred_col: eqV2-86M-omat-mp-salex_structure
     symprec=1e-5:
       rmsd: 0.0138 # Å
@@ -104,6 +105,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/eqV2/eqV2-m-omat-mp-salex.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607316
     pred_col: e_form_per_atom_eqV2-86M-omat-mp-salex
     full_test_set:
       F1: 0.896 # fraction

--- a/models/eqV2/eqV2-s-dens-mp.yml
+++ b/models/eqV2/eqV2-s-dens-mp.yml
@@ -91,6 +91,7 @@ metrics:
     κ_SRME: 1.665 # eqV2 S without denoising (no DeNS) achieves slightly worse κ_SRME=1.772
   geo_opt:
     pred_file: models/eqV2/eqV2-31M-dens-mp-p5.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607433
     pred_col: eqV2-31M-dens-MP-p5_structure
     symprec=1e-5:
       rmsd: 0.0138 # Å
@@ -108,6 +109,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/eqV2/eqV2-s-dens-mp.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607313
     pred_col: e_form_per_atom_eqV2-31M-dens-MP-p5
     full_test_set:
       F1: 0.798 # fraction

--- a/models/gnome/gnome.yml
+++ b/models/gnome/gnome.yml
@@ -62,10 +62,12 @@ notes:
 
 metrics:
   geo_opt:
-    pred_file: null # not (yet) shared by authors
-    pred_col: null
+    pred_file: # not (yet) shared by authors
+    pred_file_url:
+    pred_col:
   discovery:
     pred_file: models/gnome/2023-11-01-gnome-preds-50076332.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607301
     pred_col: e_gnome_after_relax
     full_test_set:
       F1: 0.81 # fraction

--- a/models/grace2l_r6/grace2l-r6.yml
+++ b/models/grace2l_r6/grace2l-r6.yml
@@ -54,6 +54,7 @@ metrics:
     κ_SRME: 0.525 # https://github.com/MPA2suite/k_SRME/pull/11/files
   geo_opt:
     pred_file: models/grace2l_r6/GRACE_2L_r6_11Nov2024_relaxed_structures.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607439
     pred_col: grace2l_r6_structure
     symprec=1e-5:
       rmsd: 0.0186 # Å
@@ -71,6 +72,7 @@ metrics:
       n_structures: 256513 # count
   discovery:
     pred_file: models/grace2l_r6/2024-11-21-MP_GRACE_2L_r6_11Nov2024-wbm-IS2RE-FIRE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607319
     pred_col: e_form_per_atom_grace
     full_test_set:
       F1: 0.687 # fraction

--- a/models/m3gnet/m3gnet.yml
+++ b/models/m3gnet/m3gnet.yml
@@ -58,6 +58,7 @@ metrics:
     κ_SRME: 1.412
   geo_opt:
     pred_file: models/m3gnet/2023-06-01-m3gnet-manual-sampling-wbm-IS2RE.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607415
     pred_col: m3gnet_structure
     symprec=1e-5:
       rmsd: 0.0217 # Å
@@ -75,6 +76,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/m3gnet/2023-12-28-m3gnet-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607277
     pred_col: e_form_per_atom_m3gnet
     full_test_set:
       F1: 0.576 # fraction

--- a/models/mace/mace-mp-0.yml
+++ b/models/mace/mace-mp-0.yml
@@ -73,6 +73,7 @@ metrics:
     κ_SRME: 0.647
   geo_opt:
     pred_file: models/mace/mace-mp-0/2023-12-11-mace-mp-0-wbm-IS2RE-FIRE.json.gz
+    pred_file_url:
     pred_col: mace_structure
     symprec=1e-5:
       rmsd: 0.0194 # Å
@@ -90,6 +91,7 @@ metrics:
       n_structures: 249034 # count
   discovery:
     pred_file: models/mace/mace-mp-0/2023-12-11-mace-mp-0-wbm-IS2RE-FIRE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607280
     pred_col: e_form_per_atom_mace
     full_test_set:
       F1: 0.668 # fraction

--- a/models/mace/mace-mpa-0.yml
+++ b/models/mace/mace-mpa-0.yml
@@ -72,6 +72,7 @@ metrics:
     κ_SRME: 0.412
   geo_opt:
     pred_file: models/mace/mace-mpa-0/2024-12-09-mace-mpa-0-wbm-IS2RE-FIRE.json.gz
+    pred_file_url:
     pred_col: mace_structure
     symprec=1e-2:
       rmsd: 0.0142 # Å
@@ -89,6 +90,7 @@ metrics:
       n_structures: 256963 # count
   discovery:
     pred_file: models/mace/mace-mpa-0/2024-12-09-mace-mpa-0-wbm-IS2RE-FIRE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607283
     pred_col: e_form_per_atom_mace
     full_test_set:
       F1: 0.836 # fraction

--- a/models/mattersim/mattersim-v1.yml
+++ b/models/mattersim/mattersim-v1.yml
@@ -124,11 +124,13 @@ metrics:
     κ_SRME: 0.574 # dimensionless
   geo_opt:
     pred_file: https://figshare.com/s/7604486e7e97b5a0014d
+    pred_file_url:
     pred_col:
   discovery:
     pred_file: models/mattersim/2024-12-16-mattersim-v1-5M-wbm-IS2RE.csv.gz
     # the original Graphormer-based replaced the M3GNet-based MatterSim on the leaderboard
     # pred_file: models/mattersim/2024-06-16-mattersim-graphormer-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607304
     pred_col: e_form_per_atom_mattersim
     full_test_set:
       F1: 0.838 # fraction

--- a/models/megnet/megnet.yml
+++ b/models/megnet/megnet.yml
@@ -59,6 +59,7 @@ metrics:
   geo_opt: not applicable
   discovery:
     pred_file: models/megnet/2022-11-18-megnet-wbm-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607286
     pred_col: e_form_per_atom_megnet
     full_test_set:
       F1: 0.513 # fraction

--- a/models/orb/orb-mptrj.yml
+++ b/models/orb/orb-mptrj.yml
@@ -77,6 +77,7 @@ metrics:
     κ_SRME: 1.725
   geo_opt:
     pred_file: models/orb/orb-mptrj-only-v2-20241014.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607427
     pred_col: orb_structure
     symprec=1e-5:
       rmsd: 0.0185 # Å
@@ -94,6 +95,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/orb/orbff-mptrj-only-v2-20241014.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607310
     pred_col: e_form_per_atom_orb
     full_test_set:
       F1: 0.755 # fraction

--- a/models/orb/orb.yml
+++ b/models/orb/orb.yml
@@ -77,6 +77,7 @@ metrics:
     κ_SRME: 1.732
   geo_opt:
     pred_file: models/orb/orb-v2-20241011.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607424
     pred_col: orb_structure
     symprec=1e-5:
       rmsd: 0.016 # Å
@@ -94,6 +95,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/orb/orbff-v2-20241011.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607307
     pred_col: e_form_per_atom_orb
     full_test_set:
       F1: 0.858 # fraction

--- a/models/sevennet/sevennet-0.yml
+++ b/models/sevennet/sevennet-0.yml
@@ -81,6 +81,7 @@ metrics:
     κ_SRME: 0.767
   geo_opt:
     pred_file: models/sevennet/sevennet-0/2024-07-11-sevennet-0-relaxed-structures.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607418
     pred_col: sevennet_structure
     symprec=1e-5:
       rmsd: 0.0193 # Å
@@ -98,6 +99,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/sevennet/sevennet-0/2024-07-11-sevennet-0-preds.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607289
     pred_col: e_form_per_atom_sevennet
     full_test_set:
       F1: 0.719 # fraction

--- a/models/sevennet/sevennet-l3i5.yml
+++ b/models/sevennet/sevennet-l3i5.yml
@@ -80,6 +80,7 @@ metrics:
     κ_SRME: 0.550
   geo_opt:
     pred_file: models/sevennet/sevennet-l3i5/sevennet-l3i5-structures.json.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607421
     pred_col: sevennet_structures
     symprec=1e-5:
       rmsd: 0.0182 # Å
@@ -97,6 +98,7 @@ metrics:
       n_structures: 256614 # count
   discovery:
     pred_file: models/sevennet/sevennet-l3i5/2024-12-10-sevennet-l3l5-preds.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607292
     pred_col: e_form_per_atom_chgTot_l3i5
     full_test_set:
       F1: 0.751 # fraction

--- a/models/voronoi_rf/voronoi-rf.yml
+++ b/models/voronoi_rf/voronoi-rf.yml
@@ -48,6 +48,7 @@ metrics:
   geo_opt: not applicable
   discovery:
     pred_file: models/voronoi_rf/2022-11-27-train-test/e-form-preds-IS2RE.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607295
     pred_col: e_form_per_atom_voronoi_rf
     full_test_set:
       F1: 0.344 # fraction

--- a/models/wrenformer/wrenformer.yml
+++ b/models/wrenformer/wrenformer.yml
@@ -54,6 +54,7 @@ metrics:
   geo_opt: not applicable
   discovery:
     pred_file: models/wrenformer/2022-11-15-wrenformer-ens=10-IS2RE-preds.csv.gz
+    pred_file_url: https://figshare.com/ndownloader/files/51607298
     pred_col: e_form_per_atom_wrenformer_pred_ens
     full_test_set:
       F1: 0.479 # fraction

--- a/scripts/upload_model_preds_to_figshare.py
+++ b/scripts/upload_model_preds_to_figshare.py
@@ -1,0 +1,282 @@
+"""Upload model prediction files from all models to a Figshare article.
+
+This script creates/updates a Figshare article containing model predictions from all
+models in the Matbench Discovery benchmark. This includes both energy predictions and
+ML-relaxed structures.
+"""
+
+import argparse
+import hashlib
+import os
+from collections.abc import Sequence
+from typing import Final
+
+import requests
+import yaml
+from tqdm import tqdm
+
+from matbench_discovery import PKG_DIR, ROOT
+from matbench_discovery.data import Model, round_trip_yaml
+from matbench_discovery.figshare import (
+    BASE_URL,
+    create_article,
+    make_request,
+    upload_file_to_figshare,
+)
+from matbench_discovery.models import MODEL_METADATA
+
+with open(f"{PKG_DIR}/modeling-tasks.yml") as file:
+    MODELING_TASKS: Final = yaml.safe_load(file)
+
+# Maps modeling tasks to their Figshare article IDs. New figshare articles will be
+# created if the ID is None. Be sure to paste the new article ID into the
+# FIGSHARE_ARTICLE_IDS dict below! It'll be printed by this script.
+ARTICLE_URL_PREFIX = "https://figshare.com/articles/dataset"
+FIGSHARE_ARTICLE_IDS = {
+    "discovery": 28187990,
+    "geo_opt": 28187999,
+    "phonons": None,
+}
+
+
+def get_file_hash_and_size(
+    file_name: str, chunk_size: int = 10_000_000
+) -> tuple[str, int]:
+    """Get the md5 hash and size of a file."""
+    md5 = hashlib.md5()  # noqa: S324
+    size = 0
+    with open(file_name, mode="rb") as file:
+        while data := file.read(chunk_size):
+            size += len(data)
+            md5.update(data)
+    return md5.hexdigest(), size
+
+
+def get_existing_files(article_id: int) -> dict[str, tuple[int, str]]:
+    """Get a mapping of filenames to (file_id, md5) for files already in the article."""
+    try:
+        files = make_request("GET", f"{BASE_URL}/account/articles/{article_id}/files")
+        return {file["name"]: (file["id"], file["computed_md5"]) for file in files}
+    except requests.HTTPError as exc:
+        if exc.response.status_code == 404:
+            return {}
+        raise
+
+
+def parse_args(args: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        default=[m.name for m in Model],
+        choices=[m.name for m in Model],
+        help=(
+            "Space-separated list of model names to update. If not provided, all "
+            "models will be updated."
+        ),
+    )
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        choices=list(MODELING_TASKS),
+        default=["discovery"],
+        help=(
+            "Space-separated list of modeling tasks to update. Defaults to 'discovery'."
+        ),
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Print what would be uploaded without actually uploading",
+    )
+
+    return parser.parse_args(args)
+
+
+def get_article_metadata(task: str) -> dict[str, Sequence[object]]:
+    """Get metadata for creating a new Figshare article for a modeling task."""
+    task_info = MODELING_TASKS[task]
+    return {
+        "title": f"Matbench Discovery - Model Predictions for {task_info['label']}",
+        "description": f"""
+        This dataset contains model predictions from various models evaluated on the
+        Matbench Discovery benchmark for the {task_info["label"].lower()} task.
+
+        Task description: {task_info["description"]}
+
+        For more information about the benchmark and models, visit:
+        https://matbench-discovery.materialsproject.org
+
+        Files are organized using keywords:
+        - By model: "model:<model_name>" (e.g. "model:mace-mp-0")
+        - By task: "task:{task}"
+        You can use these keywords to filter files in the Figshare UI.
+        """.strip(),
+        "defined_type": "dataset",
+        "tags": [
+            "materials-science",
+            "machine-learning",
+            "crystal-structure-prediction",
+            f"task-{task}",
+        ],
+        "categories": [
+            25162,  # Structure and dynamics of materials
+            25144,  # Inorganic materials (incl. nanomaterials)
+            25186,  # Cheminformatics and Quantitative Structure-Activity Relationships
+        ],
+    }
+
+
+def update_one_modeling_task_article(
+    task: str, models: list[str], *, dry_run: bool = False
+) -> None:
+    """Update or create a Figshare article for a modeling task."""
+    article_id = FIGSHARE_ARTICLE_IDS[task]
+
+    if article_id is not None:
+        # Check if article exists and is accessible
+        try:
+            make_request("GET", f"{BASE_URL}/account/articles/{article_id}")
+            print(f"\nFound existing article for {task} task with ID {article_id}")
+        except requests.HTTPError as exc:
+            if exc.response.status_code == 404:
+                print(f"\nArticle {article_id} for {task} task not found")
+                article_id = None
+            else:
+                raise
+
+    if article_id is None:
+        if dry_run:
+            print(f"\nWould create new article for {task} task")
+            article_id = 0
+        else:
+            metadata = get_article_metadata(task)
+            article_id = create_article(metadata)
+            print(
+                f"\n⚠️ Created new Figshare article for {task=} with {article_id=}"
+                f"\nUpdate FIGSHARE_ARTICLE_IDS in {__file__} with this ID!"
+            )
+
+    article_url = f"{ARTICLE_URL_PREFIX}/{article_id}"
+    print(f"Updating article with ID {article_id} at {article_url}")
+
+    if dry_run:
+        print("\nDry run mode - no files will be uploaded")
+
+    existing_files = get_existing_files(article_id)
+    print(f"Found {len(existing_files)} existing files")
+
+    uploaded_files: dict[str, str] = {}
+    new_files: dict[str, str] = {}
+
+    pbar = tqdm(models)
+    for model_name in pbar:
+        model = getattr(Model, model_name)
+        if not os.path.isfile(model.yaml_path):
+            print(
+                f"Warning: missing model metadata file {model.yaml_path}, skipping..."
+            )
+            continue
+
+        with open(model.yaml_path) as file:
+            model_data = round_trip_yaml.load(file)
+
+        metrics = model_data.get("metrics", {})
+        metric_data = metrics.get(task, {})
+        if not isinstance(metric_data, dict):
+            continue
+
+        pred_file = metric_data.get("pred_file")
+        if not pred_file:
+            continue
+
+        if not os.path.isfile(f"{ROOT}/{pred_file}"):
+            print(
+                f"Warning: {task} predictions for {model_name} not "
+                f"found, expected at {pred_file}"
+            )
+            continue
+
+        pbar.set_description(f"Processing {model_name}")
+        model_updated = False
+
+        filename = os.path.basename(pred_file)
+        file_path = f"{ROOT}/{pred_file}"
+
+        # Check if file already exists and has same hash
+        file_hash, _ = get_file_hash_and_size(file_path)
+        if filename in existing_files:
+            file_id, stored_hash = existing_files[filename]
+            if file_hash == stored_hash:
+                file_url = f"https://figshare.com/ndownloader/files/{file_id}"
+                uploaded_files[filename] = file_url
+                # Update model metadata if URL not present
+                if "pred_file_url" not in metric_data:
+                    metric_data["pred_file_url"] = file_url
+                    model_updated = True
+                continue
+
+        # Upload new or modified file
+        if dry_run:
+            file_url = "DRY_RUN_URL"
+        else:
+            file_id = upload_file_to_figshare(article_id, file_path)
+            file_url = f"https://figshare.com/ndownloader/files/{file_id}"
+
+        uploaded_files[filename] = file_url
+        new_files[filename] = file_url
+
+        # Update model metadata
+        metric_data["pred_file_url"] = file_url
+        model_updated = True
+
+        # Save updated model metadata if changed
+        if model_updated and not dry_run:
+            with open(model.yaml_path, "w") as file:
+                round_trip_yaml.dump(model_data, file)
+
+    print(f"\nTotal files: {len(uploaded_files)}")
+    print(f"Newly added: {len(new_files)}")
+
+    print("\nAll uploaded files:")
+    for filename, url in uploaded_files.items():
+        print(f"{filename}: {url}")
+
+    if new_files:
+        print("\nNewly added files:")
+        for filename, url in new_files.items():
+            print(f"{filename}: {url}")
+    else:
+        print("\nNo new files were added.")
+
+
+def main(args: Sequence[str] | None = None) -> int:
+    """Main function to upload model prediction files to Figshare."""
+    parsed_args = parse_args(args)
+    models_to_update = parsed_args.models or sorted(MODEL_METADATA)
+    tasks_to_update = parsed_args.tasks
+    print(f"Updating {len(models_to_update)} models: {', '.join(models_to_update)}")
+    print(f"Updating {len(tasks_to_update)} tasks: {', '.join(tasks_to_update)}")
+
+    for task in tasks_to_update:
+        try:
+            update_one_modeling_task_article(
+                task, models_to_update, dry_run=parsed_args.dry_run
+            )
+        except Exception as exc:  # prompt to delete article if something went wrong
+            msg = f"Upload failed for {task=}"
+            if model_name := locals().get("model_name", ""):
+                msg += f" and {model_name=}"
+            exc.add_note(msg)
+            raise
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upload_model_preds_to_figshare.py
+++ b/scripts/upload_model_preds_to_figshare.py
@@ -110,12 +110,7 @@ def get_article_metadata(task: str) -> dict[str, Sequence[object]]:
         Task description: {task_info["description"]}
 
         For more information about the benchmark and models, visit:
-        https://matbench-discovery.materialsproject.org
-
-        Files are organized using keywords:
-        - By model: "model:<model_name>" (e.g. "model:mace-mp-0")
-        - By task: "task:{task}"
-        You can use these keywords to filter files in the Figshare UI.
+        https://github.com/janosh/matbench-discovery.
         """.strip(),
         "defined_type": "dataset",
         "tags": [

--- a/site/src/lib/MetricsTable.svelte
+++ b/site/src/lib/MetricsTable.svelte
@@ -20,7 +20,7 @@
   export let metadata_cols = METADATA_COLS
 
   let show_pred_files_modal = false
-  let active_files: { name: string; path: string }[] = []
+  let active_files: { name: string; url: string }[] = []
   let active_model_name = ``
   let pred_file_modal: HTMLDialogElement | null = null
   let columns: HeatmapColumn[]
@@ -100,22 +100,16 @@
   }
 
   function get_pred_files(model: ModelData) {
-    const files: { name: string; path: string }[] = []
-    const raw_file_repo_url = `https://github.com/janosh/matbench-discovery/raw/main`
+    const files: { name: string; url: string }[] = []
 
     function find_pred_files(obj: object, parent_key = ``) {
       if (!obj || typeof obj !== `object`) return
 
       for (const [key, val] of Object.entries(obj)) {
-        if (
-          [`pred_file`, `pred_file_url`].includes(key) &&
-          val &&
-          typeof val === `string`
-        ) {
+        if (key == `pred_file_url` && val && typeof val === `string`) {
           // Get parent key without _pred_file suffix for label lookup
           const pretty_label = modeling_tasks[parent_key]?.label || parent_key
-          const path = val.startsWith(`http`) ? val : `${raw_file_repo_url}/${val}`
-          files.push({ name: pretty_label, path })
+          files.push({ name: pretty_label, url: val })
         } else if (typeof val === `object`) {
           find_pred_files(val, key)
         }
@@ -236,7 +230,7 @@
       {#each active_files as file}
         <li>
           <a
-            href={file.path}
+            href={file.url}
             target="_blank"
             rel="noopener noreferrer"
             on:click={() => (show_pred_files_modal = false)}

--- a/site/src/lib/model-schema.d.ts
+++ b/site/src/lib/model-schema.d.ts
@@ -83,12 +83,15 @@ export interface ModelMetadata {
   metrics?: {
     phonons?:
       | {
+          pred_file?: string | null
+          pred_file_url?: string | null
           κ_SRME?: number
         }
       | ('not applicable' | 'not available')
     geo_opt?:
       | {
           pred_file: string | null
+          pred_file_url: string | null
           pred_col: string | null
           'symprec=1e-5'?: {
             rmsd?: number
@@ -118,8 +121,9 @@ export interface ModelMetadata {
       | ('not applicable' | 'not available')
     discovery?: {
       additionalProperties?: never
-      pred_file?: string
-      pred_col?: string
+      pred_file: string
+      pred_file_url: string
+      pred_col: string
       full_test_set?: {
         F1?: number
         DAF?: number

--- a/tests/model-schema.yml
+++ b/tests/model-schema.yml
@@ -146,6 +146,10 @@ properties:
           - type: object
             additionalProperties: false
             properties:
+              pred_file:
+                type: [string, "null"]
+              pred_file_url:
+                type: [string, "null"]
               κ_SRME:
                 type: number
           - type: string
@@ -154,9 +158,11 @@ properties:
         oneOf:
           - type: object
             additionalProperties: false
-            required: [pred_file, pred_col]
+            required: [pred_file, pred_col, pred_file_url]
             properties:
               pred_file:
+                type: [string, "null"]
+              pred_file_url:
                 type: [string, "null"]
               pred_col:
                 type: [string, "null"]
@@ -182,10 +188,13 @@ properties:
             enum: [not applicable, not available]
       discovery:
         additionalProperties: false
+        required: [pred_file, pred_col, pred_file_url]
         type: object
         properties:
           additionalProperties: false
           pred_file:
+            type: string
+          pred_file_url:
             type: string
           pred_col:
             type: string

--- a/tests/test_figshare.py
+++ b/tests/test_figshare.py
@@ -1,0 +1,149 @@
+"""Unit tests for Figshare API helper functions."""
+
+from typing import Any
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+import requests
+
+from matbench_discovery.figshare import (
+    create_article,
+    get_file_hash_and_size,
+    make_request,
+    upload_file_to_figshare,
+)
+
+
+@pytest.mark.parametrize(
+    "content,expected,binary",
+    [
+        (b'{"key": "value"}', {"key": "value"}, False),  # JSON
+        (b"binary_data", b"binary_data", True),  # Binary
+        (b"plain text", b"plain text", False),  # Text
+        (b"", b"", False),  # Empty
+        (b"{invalid-json}", b"{invalid-json}", False),  # Invalid JSON
+    ],
+)
+def test_make_request(content: bytes, expected: Any, binary: bool) -> None:
+    """Test make_request with various response types."""
+    mock_response = MagicMock(content=content)
+
+    with patch("requests.request", return_value=mock_response):
+        assert make_request("GET", "test_url", binary=binary) == expected
+
+
+@pytest.mark.parametrize(
+    "error_content",
+    [b"Not found", b'{"error": "Invalid token"}', b""],
+)
+def test_make_request_errors(error_content: bytes) -> None:
+    """Test make_request error handling."""
+    mock_response = MagicMock(content=error_content)
+    mock_response.raise_for_status.side_effect = requests.HTTPError()
+
+    with (
+        patch("requests.request", return_value=mock_response),
+        pytest.raises(requests.HTTPError) as exc_info,
+    ):
+        make_request("GET", "test_url")
+
+    assert f"body={error_content.decode()}" in str(exc_info.value.__notes__)
+
+
+@pytest.mark.parametrize(
+    "metadata,article_id",
+    [
+        ({"title": "Test Article"}, 12345),
+        ({"title": "Test", "description": "Desc"}, 67890),
+    ],
+)
+def test_create_article_variants(
+    metadata: dict[str, str], article_id: int, capsys: pytest.CaptureFixture
+) -> None:
+    """Test article creation with different metadata."""
+    with patch(
+        "matbench_discovery.figshare.make_request",
+        side_effect=[{"location": "loc"}, {"id": article_id}],
+    ):
+        assert create_article(metadata) == article_id
+
+        # Check printed output
+        stdout, stderr = capsys.readouterr()
+        assert stdout == f"Created article: loc with title {metadata['title']}\n\n"
+        assert stderr == ""
+
+
+@pytest.mark.parametrize(
+    "test_data,expected_size,expected_md5",
+    [
+        (b"test data", 9, "eb733a00c0c9d336e65691a37ab54293"),
+        (b"", 0, "d41d8cd98f00b204e9800998ecf8427e"),  # Empty
+        (b"hello world", 11, "5eb63bbbe01eeed093cb22bb8f5acdc3"),  # Regular
+    ],
+)
+def test_get_file_hash_and_size_variants(
+    test_data: bytes, expected_size: int, expected_md5: str
+) -> None:
+    """Test file hash and size calculation with different file contents."""
+    with patch("builtins.open", mock_open(read_data=test_data)):
+        md5, size = get_file_hash_and_size("test_file")
+        assert size == expected_size
+        assert md5 == expected_md5
+
+
+def test_get_file_hash_and_size_large_file() -> None:
+    """Test hash and size calculation for large files using chunked reading."""
+    chunks = [b"chunk1", b"chunk2", b"chunk3"]
+    mock_file = MagicMock(
+        __enter__=MagicMock(
+            return_value=MagicMock(read=MagicMock(side_effect=[*chunks, b""]))
+        )
+    )
+
+    with patch("builtins.open", return_value=mock_file):
+        md5, size = get_file_hash_and_size("test_file", chunk_size=5)
+        assert size == sum(len(chunk) for chunk in chunks)
+        assert md5 == "2aca0a9378723b1bed59975523ed50cd"
+
+        read_calls = mock_file.__enter__().read.call_args_list
+        assert all(call.args[0] == 5 for call in read_calls)
+        assert len(read_calls) == len(chunks) + 1  # +1 for EOF check
+
+
+@pytest.mark.parametrize(
+    "file_parts",
+    [
+        [{"partNo": 1, "startOffset": 0, "endOffset": 9}],  # Single part
+        [  # Multiple parts
+            {"partNo": 1, "startOffset": 0, "endOffset": 4},
+            {"partNo": 2, "startOffset": 5, "endOffset": 9},
+        ],
+        [{"partNo": 1, "startOffset": 0, "endOffset": 0}],  # Empty file
+    ],
+)
+def test_upload_file_to_figshare_variants(file_parts: list[dict[str, int]]) -> None:
+    """Test file upload with different file parts configurations."""
+    mock_responses = {
+        "POST": {"location": "file_location"},
+        "GET": {"id": 67890, "upload_url": "upload_url", "parts": file_parts},
+        "PUT": None,  # PUT requests return None on success
+    }
+
+    def mock_make_request(method: str, url: str, **_kwargs: Any) -> Any:
+        """Mock request handler that returns appropriate response for each method."""
+        if method == "GET" and url == "upload_url":
+            return {"parts": file_parts}
+        return mock_responses[method]
+
+    with (
+        patch(
+            "matbench_discovery.figshare.make_request",
+            side_effect=mock_make_request,
+        ),
+        patch(
+            "matbench_discovery.figshare.get_file_hash_and_size",
+            return_value=("hash", 10),
+        ),
+        patch("builtins.open", mock_open(read_data=b"test data")),
+    ):
+        assert upload_file_to_figshare(12345, "test_file") == 67890


### PR DESCRIPTION
in separate figshare articles. the figshare file links are used in `MetricsTable` to power download buttons

![Screenshot 2025-01-10 at 17 52 56](https://github.com/user-attachments/assets/1fe27b63-be65-40b2-a5a4-06d53db19522)
