### PR TITLE
`training-sets.yml` add `download_url` and `open: bool` keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,9 @@ repos:
       - id: check-jsonschema
         files: ^models/.+/.+\.yml$
         args: [--schemafile, tests/model-schema.yml]
+      - id: check-jsonschema
+        files: ^data/training-sets\.yml$
+        args: [--schemafile, tests/training-set-schema.yml]
       - id: check-github-actions
 
   - repo: https://github.com/RobertCraigie/pyright-python

--- a/data/phonons/phonondb_103_pbe_eda.py
+++ b/data/phonons/phonondb_103_pbe_eda.py
@@ -20,7 +20,7 @@ __date__ = "2025-01-14"
 
 
 # %%
-atoms_list = ase.io.read(DataFiles.phonondb_pbe_structures.path, index=":")
+atoms_list = ase.io.read(DataFiles.phonondb_pbe_103_structures.path, index=":")
 
 
 # %% visually inspect first 12 structures

--- a/data/training-sets.yml
+++ b/data/training-sets.yml
@@ -1,30 +1,39 @@
 MP 2022:
   title: MP v2022.10.28
-  url: https://figshare.com/ndownloader/files/40344436
+  url: https://docs.materialsproject.org/changes/database-versions#v2022.10.28
+  download_url: https://figshare.com/ndownloader/files/40344436
   n_structures: 154_719
+  open: true
 
 MPtrj:
   title: MPtrj
   url: https://figshare.com/articles/dataset/23713842
+  download_url: https://figshare.com/ndownloader/files/41619375
   n_structures: 1_580_395
   n_materials: 145_923
+  open: true
 
 MPF:
   title: MPF.2021.2.8
   url: https://figshare.com/articles/dataset/19470599
+  download_url: https://figshare.com/ndownloader/articles/19470599/versions/3
   n_structures: 188_349
   n_materials: 62_783
+  open: true
 
 MP Graphs:
   title: Graphs of MP 2019
   url: https://figshare.com/articles/dataset/8097992
+  download_url: https://figshare.com/ndownloader/articles/8097992/versions/2
   n_structures: 133_420
+  open: true
 
 GNoME:
   title: GNoME
   url: https://doi.org/10.1038/s41586-023-06735-9
   n_structures: 89_000_000
   n_materials: 6_000_000
+  open: false
 
 MatterSim:
   title: MatterSim
@@ -32,12 +41,15 @@ MatterSim:
   n_structures: 17_000_000
   temperature_range: 0-5000 K
   pressure_range: 0-1000 GPa
+  open: false
 
 Alex:
   title: Alexandria
   url: https://alexandria.icams.rub.de
+  download_url: https://alexandria.icams.rub.de/data/pbe # too large for single download, split into subfiles
   n_structures: 30_497_628
   n_materials: 3_100_000
+  open: true
 
 OMat24:
   title: OMat24
@@ -45,9 +57,20 @@ OMat24:
   # this is the number of Alexandria materials that was sampled from, but according to Luis unclear if all were indeed sampled so this is an upper bound
   n_materials: 3_227_606
   n_structures: 100_824_585
+  open: true
 
 sAlex:
-  title: subsampled Alexandria
+  title: subsampled Alexandria Training Set
   url: https://huggingface.co/datasets/fairchem/OMAT24#salex-dataset
+  download_url: https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/sAlex/train.tar.gz
   n_materials: 3_227_606
   n_structures: 10_447_765
+  open: true
+
+sAlex Validation:
+  title: subsampled Alexandria Validation Set
+  url: https://huggingface.co/datasets/fairchem/OMAT24#salex-dataset
+  download_url: https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/sAlex/val.tar.gz
+  n_materials: 170_905 # approximate value! TODO confirm this
+  n_structures: 553_218
+  open: true

--- a/matbench_discovery/__init__.py
+++ b/matbench_discovery/__init__.py
@@ -1,10 +1,8 @@
 """Global variables used all across the matbench_discovery package."""
 
-import json
 import os
 import warnings
 from datetime import UTC, datetime
-from importlib.metadata import Distribution, version
 
 import plotly.express as px
 import plotly.io as pio
@@ -13,13 +11,10 @@ import pymatviz as pmv  # needed for pymatviz_dark template
 from matbench_discovery.enums import MbdKey
 
 PKG_NAME = "matbench-discovery"
-__version__ = version(PKG_NAME)
-direct_url = Distribution.from_name(PKG_NAME).read_text("direct_url.json") or "{}"
-pkg_is_editable = json.loads(direct_url).get("dir_info", {}).get("editable", False)
+__version__ = "1.3.1"
 
-PKG_DIR = os.path.dirname(__file__)
-# repo root directory if editable install, else the pkg directory
-ROOT = os.path.dirname(PKG_DIR)
+PKG_DIR = os.path.dirname(__file__)  # Python package directory
+ROOT = os.path.dirname(PKG_DIR)  # repo root directory
 DATA_DIR = f"{ROOT}/data"  # directory to store raw data
 SITE_FIGS = f"{ROOT}/site/src/figs"  # directory for interactive figures
 # directory to write model analysis for website

--- a/matbench_discovery/data-files.yml
+++ b/matbench_discovery/data-files.yml
@@ -82,9 +82,15 @@ wbm_summary:
   description: Computed material properties only, no structures. Available properties are VASP energy, formation energy, energy above the convex hull, volume, band gap, number of sites per unit cell, and more.
   md5: fb23d85dab61fab001b92cb0ac4f8f3d
 
-phonondb_pbe_structures:
+phonondb_pbe_103_structures:
   url: https://figshare.com/ndownloader/files/51680888
   path: phonons/2024-11-09-phononDB-PBE-103-structures.extxyz
+  description: 103 phononDB structures run by Togo with PBE settings received in private communication. See https://github.com/atztogo/phonondb/blob/bba206/README.md#url-links-to-phono3py-finite-displacement-method-inputs-of-103-compounds-on-mdr-at-nims-pbe for details.
+  md5: a396d4c517fa6d57defeffc6c83f0118
+
+phonondb_pbe_103_kappa_nac:
+  url:
+  path: phonons/2024-11-09-kappas-phononDB-PBE-noNAC.json.gz
   description: 103 phononDB structures run by Togo with PBE settings received in private communication. See https://github.com/atztogo/phonondb/blob/bba206/README.md#url-links-to-phono3py-finite-displacement-method-inputs-of-103-compounds-on-mdr-at-nims-pbe for details.
   md5: a396d4c517fa6d57defeffc6c83f0118
 

--- a/matbench_discovery/data-files.yml
+++ b/matbench_discovery/data-files.yml
@@ -89,7 +89,7 @@ phonondb_pbe_103_structures:
   md5: a396d4c517fa6d57defeffc6c83f0118
 
 phonondb_pbe_103_kappa_nac:
-  url:
+  url: https://figshare.com/ndownloader/files/51939920
   path: phonons/2024-11-09-kappas-phononDB-PBE-noNAC.json.gz
   description: 103 phononDB structures run by Togo with PBE settings received in private communication. See https://github.com/atztogo/phonondb/blob/bba206/README.md#url-links-to-phono3py-finite-displacement-method-inputs-of-103-compounds-on-mdr-at-nims-pbe for details.
   md5: a396d4c517fa6d57defeffc6c83f0118

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -329,7 +329,10 @@ class DataFiles(Files):
     @property
     def url(self) -> str:
         """URL associated with the file."""
-        return self.yaml[self.name]["url"]
+        url = self.yaml[self.name].get("url")
+        if url is None:
+            raise ValueError(f"{self.name!r} does not have a URL")
+        return url
 
     @property
     def description(self) -> str:

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -26,10 +26,9 @@ from pymatviz.enums import Key
 from ruamel.yaml import YAML
 from tqdm import tqdm
 
-from matbench_discovery import DATA_DIR, PKG_DIR, ROOT, pkg_is_editable
+from matbench_discovery import DATA_DIR, PKG_DIR, ROOT
 from matbench_discovery.enums import MbdKey, TestSubset
 
-# ruff: noqa: T201
 T = TypeVar("T", bound="Files")
 
 # repo URL to raw files on GitHub
@@ -37,7 +36,10 @@ RAW_REPO_URL = "https://github.com/janosh/matbench-discovery/raw"
 # directory to cache downloaded data files
 DEFAULT_CACHE_DIR = os.getenv(
     "MATBENCH_DISCOVERY_CACHE_DIR",
-    DATA_DIR if pkg_is_editable else os.path.expanduser("~/.cache/matbench-discovery"),
+    DATA_DIR  # use DATA_DIR to locally cache data files if full repo was cloned
+    if os.path.isdir(DATA_DIR)
+    # use ~/.cache if matbench-discovery was installed from PyPI
+    else os.path.expanduser("~/.cache/matbench-discovery"),
 )
 
 
@@ -306,7 +308,10 @@ class DataFiles(Files):
     )
     wbm_summary = "wbm/2023-12-13-wbm-summary.csv.gz"
     alignn_checkpoint = "2023-06-02-pbenner-best-alignn-model.pth.zip"
-    phonondb_pbe_structures = "phonons/2024-11-09-phononDB-PBE-103-structures.extxyz"
+    phonondb_pbe_103_structures = (
+        "phonons/2024-11-09-phononDB-PBE-103-structures.extxyz"
+    )
+    phonondb_pbe_103_kappa_nac = "phonons/2024-11-09-kappas-phononDB-PBE-noNAC.json.gz"
 
     @functools.cached_property
     def yaml(self) -> dict[str, dict[str, str]]:

--- a/scripts/metrics/eval_discovery.py
+++ b/scripts/metrics/eval_discovery.py
@@ -185,7 +185,7 @@ for model in df_metrics_uniq_protos.index:
                 n_materials_total += n_materials
 
                 title = dataset_info.get("title", key)
-                dataset_urls[key or title] = dataset_info.get("url", "")
+                dataset_urls[key or title] = dataset_info.get("download_url", "")
 
                 if n_materials != n_structs:
                     dataset_tooltip_lines += [

--- a/site/src/lib/GeoOptMetricsTable.svelte
+++ b/site/src/lib/GeoOptMetricsTable.svelte
@@ -2,8 +2,8 @@
   import {
     HeatmapTable,
     MODEL_METADATA,
-    model_is_compliant,
     get_metric_rank_order,
+    model_is_compliant,
   } from '$lib'
   import { pretty_num } from 'elementari'
   import type { HeatmapColumn } from './types.ts'
@@ -123,9 +123,3 @@
 </script>
 
 <HeatmapTable data={metrics_data} {columns} {...$$restProps} />
-
-<style>
-  :global(.heatmap-table td:not(:first-child)) {
-    text-align: right;
-  }
-</style>

--- a/site/src/lib/MetricsTable.svelte
+++ b/site/src/lib/MetricsTable.svelte
@@ -48,7 +48,7 @@
       total_materials += n_materials
 
       const title = training_set_info.title || train_set
-      data_urls[train_set || title] = training_set_info.url || ``
+      data_urls[train_set || title] = training_set_info.download_url || ``
 
       if (n_materials !== n_structs) {
         tooltip.push(

--- a/site/src/lib/types.ts
+++ b/site/src/lib/types.ts
@@ -81,6 +81,7 @@ export type TrainingSet =
   | {
       title: string
       url: string
+      download_url: string
       n_structures: number
       n_materials?: number
       [k: string]: unknown

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -48,7 +48,8 @@
     },
     unique_prototypes: {
       title: `Unique Prototypes`,
-      tooltip: `Metrics computed only on unique structure prototypes`,
+      tooltip: `Metrics computed only on ~215k unique structure prototypes in WBM determined by matching Aflow-style prototype strings.`,
+      link: `https://github.com/janosh/matbench-discovery/blob/fd1dda6c/data/wbm/compile_wbm_test_set.py#L632-L705`,
     },
     most_stable_10k: {
       title: `10k Most Stable`,
@@ -69,13 +70,18 @@
 <Readme>
   <figure style="margin-top: 4em;" slot="metrics-table">
     <div class="discovery-set-toggle">
-      {#each Object.entries(discovery_set_labels) as [key, { title, tooltip }]}
+      {#each Object.entries(discovery_set_labels) as [key, { title, tooltip, link }]}
         <Tooltip text={tooltip} tip_style="z-index: 2; font-size: 0.8em;">
           <button
             class:active={discovery_set === key}
             on:click={() => (discovery_set = key)}
           >
             {title}
+            {#if link}
+              <a href={link} target="_blank">
+                <Icon icon="octicon:info" inline />
+              </a>
+            {/if}
           </button>
         </Tooltip>
       {/each}

--- a/site/tests/model-card.test.ts
+++ b/site/tests/model-card.test.ts
@@ -82,7 +82,7 @@ describe(`ModelCard`, () => {
       const training_set_key = model.training_set[0]
       const training_set_info = TRAINING_SETS[training_set_key]
 
-      expect(training_set_links[0].href).toBe(training_set_info.url)
+      expect(training_set_links[0].href).toBe(training_set_info.download_url)
 
       // Use pretty_num to match the actual formatted output
       const formatted_structures = pretty_num(training_set_info.n_structures)

--- a/site/tests/model-card.test.ts
+++ b/site/tests/model-card.test.ts
@@ -82,7 +82,7 @@ describe(`ModelCard`, () => {
       const training_set_key = model.training_set[0]
       const training_set_info = TRAINING_SETS[training_set_key]
 
-      expect(training_set_links[0].href).toBe(training_set_info.download_url)
+      expect(training_set_links[0].href).toBe(training_set_info.url)
 
       // Use pretty_num to match the actual formatted output
       const formatted_structures = pretty_num(training_set_info.n_structures)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,17 +2,27 @@ import os
 from glob import glob
 
 import pytest
+import yaml
 
-from matbench_discovery import __version__
+from matbench_discovery import DATA_DIR, __version__
 from matbench_discovery.data import Model
 from matbench_discovery.models import MODEL_DIRS, MODEL_METADATA, model_is_compliant
 
+with open(f"{DATA_DIR}/training-sets.yml") as file:
+    TRAINING_SETS = yaml.safe_load(file)
 
-def parse_version(v: str) -> tuple[int, ...]:
-    return tuple(map(int, v.split(".")))
+OPEN_DATASETS = {
+    dataset["title"] for dataset in TRAINING_SETS.values() if dataset["open"]
+}
+
+
+def parse_version(version: str) -> tuple[int, ...]:
+    """Parse version string into tuple of integers."""
+    return tuple(map(int, version.split(".")))
 
 
 def test_model_dirs_have_metadata() -> None:
+    """Test that all model directories have required metadata."""
     required = {
         "authors": list,  # dict with name, affiliation, orcid?, email?
         "date_added": str,
@@ -33,14 +43,27 @@ def test_model_dirs_have_metadata() -> None:
         model_dir = metadata["model_dir"]
         for key, expected in required.items():
             assert key in metadata, f"Required {key=} missing in {model_dir}"
-            actual_val = metadata[key]
+
             if key == "training_set":
+                training_sets = metadata[key]
                 # allow either string key or dict
-                assert isinstance(actual_val, dict | str | list)
-            if (isinstance(expected, dict) and key != "training_set") or (
-                key == "training_set" and isinstance(actual_val, dict)
-            ):
-                missing_keys = {*expected} - {*actual_val}  # type: ignore[misc]
+                assert isinstance(training_sets, list)
+                assert set(training_sets) <= {
+                    dataset["title"] for dataset in TRAINING_SETS.values()
+                }, f"Invalid training set: {training_sets}"
+                # Check if model was trained only on open datasets
+                openness = metadata["openness"].endswith("OD")
+                if set(training_sets) <= OPEN_DATASETS and not openness:
+                    # if so, check that the model is marked as OD (open data)
+                    raise ValueError(
+                        f"{model_name} was only trained on open datasets but is "
+                        f"marked as {metadata['openness']}. Should be marked as "
+                        "OD."
+                    )
+
+            actual_val = metadata[key]
+            if isinstance(expected, dict) and key != "training_set":
+                missing_keys = {*expected} - {*actual_val}
                 assert not missing_keys, f"{missing_keys=} under {key=} in {model_dir}"
                 continue
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -48,9 +48,9 @@ def test_model_dirs_have_metadata() -> None:
                 training_sets = metadata[key]
                 # allow either string key or dict
                 assert isinstance(training_sets, list)
-                assert set(training_sets) <= {
-                    dataset["title"] for dataset in TRAINING_SETS.values()
-                }, f"Invalid training set: {training_sets}"
+                assert set(training_sets) <= {*TRAINING_SETS}, (
+                    f"Invalid training set: {training_sets}"
+                )
                 # Check if model was trained only on open datasets
                 openness = metadata["openness"].endswith("OD")
                 if set(training_sets) <= OPEN_DATASETS and not openness:

--- a/tests/training-set-schema.yml
+++ b/tests/training-set-schema.yml
@@ -1,0 +1,34 @@
+"$schema": http://json-schema.org/draft-07/schema#
+type: object
+patternProperties:
+  "^[a-zA-Z0-9 ]+$": # allow alphanumeric names with spaces
+    type: object
+    additionalProperties: false
+    required:
+      - title
+      - url
+      - n_structures
+      - open
+    properties:
+      title:
+        type: string
+      url:
+        type: string
+        format: uri
+      download_url:
+        type: string
+        format: uri
+      n_structures:
+        type: integer
+        minimum: 1
+      n_materials:
+        type: integer
+        minimum: 1
+      temperature_range:
+        type: string
+        pattern: "^\\d+-\\d+ K$" # e.g. "0-5000 K"
+      pressure_range:
+        type: string
+        pattern: "^\\d+-\\d+ GPa$" # e.g. "0-1000 GPa"
+      open:
+        type: boolean


### PR DESCRIPTION
thanks @CompRhys for catching https://github.com/janosh/matbench-discovery/pull/191#discussion_r1929869956. this PR will prevent future instances of inconsistent model and data openness

- pre-commit check that all `training-sets.yml` entries comply with schema in `training-set-schema.yml`
- Modify scripts and site components to use `download_url` instead of `url`
- Add validation in `test_models.py` to check `model['openness']` and `training_set['open']` match
- add `DataFiles.phonondb_pbe_103_kappa_nac` attribute
- rename `phonondb_pbe_structures` to `phonondb_pbe_103_structures` in `data-files.yml`
- simplify version and package info collection in `__init__.py` (checking for `DATA_DIR` existence rather than `importlib.metadata.Distribution.direct_url` to detect editable installs which broke `ray.remote(runtime_env={py_modules=[matbench_discovery]})`)
