### PR TITLE
Auto-publish figshare articles after uploading new model pred files

### DIFF
--- a/matbench_discovery/enums.py
+++ b/matbench_discovery/enums.py
@@ -436,8 +436,11 @@ class Model(Files, base_dir=f"{ROOT}/models"):
         """File path associated with the file URL if it exists, otherwise
         download the file first, then return the path.
         """
-        phonons_metrics = self.metrics.get("phonons", {})
-        if phonons_metrics in ("not available", "not applicable"):
+        phonons_metrics = self.metrics.get("phonons")
+        if phonons_metrics is None or phonons_metrics in (
+            "not available",
+            "not applicable",
+        ):
             return None
         rel_path = phonons_metrics.get("kappa_103", {}).get("pred_file")
         file_url = phonons_metrics.get("kappa_103", {}).get("pred_file_url")

--- a/matbench_discovery/remote/figshare.py
+++ b/matbench_discovery/remote/figshare.py
@@ -301,3 +301,26 @@ def upload_file_if_needed(
     # Upload the file
     file_id = upload_file(article_id, file_path, file_name)
     return file_id, True
+
+
+def publish_article(article_id: int, *, verbose: bool = True) -> bool:
+    """Publish a Figshare article, making it publicly available.
+
+    Args:
+        article_id (int): ID of the article to publish.
+        verbose (bool, optional): Whether to print status messages. Defaults to True.
+
+    Returns:
+        bool: True if the article was successfully published.
+    """
+    post_url = f"{BASE_URL}/account/articles/{article_id}/publish"
+    try:
+        make_request("POST", post_url)
+        if verbose:
+            article_url = f"{ARTICLE_URL_PREFIX}/{article_id}"
+            print(f"Successfully published article {article_id} at {article_url}")
+    except Exception as exc:
+        if verbose:
+            print(f"Failed to publish article {article_id}: {exc}")
+        return False
+    return True

--- a/models/deepmd/dpa3-v2-mptrj.yml
+++ b/models/deepmd/dpa3-v2-mptrj.yml
@@ -95,7 +95,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.959
       pred_file: models/deepmd/dpa3-v2-mptrj/2025-03-14-kappa-103-FIRE-dist=0.01-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/52988744
+      pred_file_url: https://figshare.com/files/53090582
   geo_opt:
     pred_file: models/deepmd/dpa3-v2-mptrj/2025-03-14-wbm-geo-opt.json.gz
     struct_col: dp_structure

--- a/models/deepmd/dpa3-v2-openlam.yml
+++ b/models/deepmd/dpa3-v2-openlam.yml
@@ -97,7 +97,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.687
       pred_file: models/deepmd/dpa3-v2-openlam/2025-03-14-kappa-103-FIRE-dist=0.01-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/53018855
+      pred_file_url: https://figshare.com/files/53090585
   geo_opt:
     pred_file: models/deepmd/dpa3-v2-openlam/2025-03-14-wbm-geo-opt.json.gz
     struct_col: dp_structure

--- a/models/eSEN/eSEN-30m-mp.yml
+++ b/models/eSEN/eSEN-30m-mp.yml
@@ -64,7 +64,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.3398
       pred_file: models/eSEN/eSEN-30m-mp/2025-03-18-kappa-103-FIRE-dist=0.03-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/53090276
+      pred_file_url: https://figshare.com/files/53090588
   geo_opt:
     pred_file: models/eSEN/eSEN-30m-mp/2025-03-17-wbm-geo-opt.json.gz
     pred_file_url: https://figshare.com/files/53054693

--- a/models/eSEN/eSEN-30m-oam.yml
+++ b/models/eSEN/eSEN-30m-oam.yml
@@ -64,7 +64,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.1704
       pred_file: models/eSEN/eSEN-30m-oam/2025-03-18-kappa-103-FIRE-dist=0.03-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/53090219
+      pred_file_url: https://figshare.com/files/53090591
   geo_opt:
     pred_file: models/eSEN/eSEN-30m-oam/2025-03-17-wbm-geo-opt.json.gz
     pred_file_url: https://figshare.com/files/53054672

--- a/models/grace/grace-1l-oam.yml
+++ b/models/grace/grace-1l-oam.yml
@@ -58,7 +58,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.516 # https://github.com/MPA2suite/k_SRME/pull/20
       pred_file: models/grace/grace-1L-oam/2025-02-02-kappa-103-FIRE-dist=0.01-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/52204910
+      pred_file_url: https://figshare.com/files/53090597
   geo_opt:
     pred_file: models/grace/grace-1L-oam/2025-02-02-wbm-geo-opt.json.gz
     pred_file_url: https://figshare.com/files/52204904

--- a/models/grace/grace-2l-oam.yml
+++ b/models/grace/grace-2l-oam.yml
@@ -58,7 +58,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.294 # https://github.com/MPA2suite/k_SRME/pull/20
       pred_file: models/grace/grace-2l-oam/2025-01-28-kappa-103-FIRE-dist=0.01-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/52204916
+      pred_file_url: https://figshare.com/files/53090594
   geo_opt:
     pred_file: models/grace/grace-2l-oam/2025-01-28-wbm-geo-opt.json.gz
     pred_file_url: https://figshare.com/files/52204907

--- a/models/matris/matris-v050-mptrj.yml
+++ b/models/matris/matris-v050-mptrj.yml
@@ -84,7 +84,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.861
       pred_file: models/matris/matris-0.5.0-mptrj/2025-03-12-kappa-103-fire-dist=0.01-fmax1e-4-symprec1e-5.json.gz
-      pred_file_url: https://figshare.com/files/53000390
+      pred_file_url: https://figshare.com/files/53090600
   geo_opt:
     pred_file: models/matris/matris-0.5.0-mptrj/2025-03-12-wbm-geo-opt.json.gz
     pred_file_url: https://figshare.com/files/53000177

--- a/models/sevennet/sevennet-mf-ompa.yml
+++ b/models/sevennet/sevennet-mf-ompa.yml
@@ -96,7 +96,7 @@ metrics:
     kappa_103:
       κ_SRME: 0.317
       pred_file: models/sevennet/sevennet-mf-ompa/2025-03-11-kappa-103-FIRE-dist=0.03-fmax=1e-4-symprec=1e-5.json.gz
-      pred_file_url: https://figshare.com/files/52984310
+      pred_file_url: https://figshare.com/files/53090603
   geo_opt:
     pred_file: models/sevennet/sevennet-mf-ompa/2025-03-11-wbm-geo-opt-FIRE.json.gz
     pred_file_url: https://figshare.com/files/52983491

--- a/scripts/upload_model_preds_to_figshare.py
+++ b/scripts/upload_model_preds_to_figshare.py
@@ -304,6 +304,11 @@ def update_one_modeling_task_article(
                 skipped_files.items(), start=1
             ):
                 print(f"{idx}. {model.name} {filename}: {url}")
+
+        # Publish the article if any new files were added and it's not a dry run
+        if (new_files or updated_files) and not dry_run:
+            print("\nNew or updated files were added. Publishing the article...")
+            figshare.publish_article(article_id)
     else:
         print("\nNo files were added or updated.")
 

--- a/site/src/lib/MetricsTable.svelte
+++ b/site/src/lib/MetricsTable.svelte
@@ -21,6 +21,7 @@
     DiscoverySet,
     HeatmapColumn,
     ModelData,
+    TableData,
   } from './types'
 
   interface Props {
@@ -274,7 +275,7 @@
           const phonons = model.metrics?.phonons
           const kappa =
             phonons && typeof phonons === `object` && `kappa_103` in phonons
-              ? phonons.kappa_103?.κ_SRME
+              ? (phonons.kappa_103?.κ_SRME as number | undefined)
               : undefined
 
           // Calculate combined score
@@ -303,9 +304,9 @@
             'κ<sub>SRME</sub>': kappa,
             RMSD: rmsd,
             'Training Set': format_train_set(model.training_set),
-            Params: `<span title="${pretty_num(model.model_params, `,`)} trainable model parameters">${pretty_num(model.model_params)}</span>`,
+            Params: `<span title="${pretty_num(model.model_params, `,`)} trainable model parameters" data-sort-value="${model.model_params}">${pretty_num(model.model_params)}</span>`,
             Targets: targets_str,
-            'Date Added': `<span title="${long_date(model.date_added)}">${model.date_added}</span>`,
+            'Date Added': `<span title="${long_date(model.date_added)}" data-sort-value="${new Date(model.date_added).getTime()}">${model.date_added}</span>`,
             // Add Links as a special property
             Links: {
               paper: {
@@ -335,7 +336,7 @@
   }
 
   // Make metrics_data explicitly reactive with $state
-  let metrics_data = $state()
+  let metrics_data = $state<TableData>([])
 
   // Make metrics_data is recalculated whenever filter settings, props, or metric_config changes
   $effect(() => {
@@ -386,7 +387,7 @@
       on_filter_change={(show_energy, show_noncomp) => {
         handle_filter_change(show_energy, show_noncomp)
       }}
-      on_col_change={(column, visible) => {
+      on_col_change={(column: string, visible: boolean) => {
         // Update visible_cols state instead of columns
         visible_cols[column] = visible
       }}

--- a/site/src/lib/metrics.ts
+++ b/site/src/lib/metrics.ts
@@ -5,10 +5,14 @@ export const METADATA_COLS: HeatmapColumn[] = [
   { label: `Training Set`, tooltip: `Size of and link to model training set` },
   { label: `Params`, tooltip: `Number of trainable model parameters` },
   { label: `Targets`, tooltip: `Target property used to train the model` },
-  { label: `Date Added`, tooltip: `Submission date to the leaderboard` },
+  {
+    label: `Date Added`,
+    tooltip: `Submission date to the leaderboard`,
+  },
   {
     label: `Links`,
     tooltip: `Model resources: paper, code repository and submission pull request`,
+    sortable: false,
   },
 ]
 

--- a/site/src/lib/types.ts
+++ b/site/src/lib/types.ts
@@ -97,6 +97,7 @@ export type HeatmapColumn = {
   format?: string // d3-format string
   sticky?: boolean // sticky column
   hidden?: boolean // hide column
+  sortable?: boolean // whether column is sortable, defaults to true
 }
 
 export const DISCOVERY_SETS = [
@@ -126,6 +127,6 @@ export interface CombinedMetricConfig {
   description: string
 }
 
-export type CellVal = string | number | undefined | null
+export type CellVal = string | number | undefined | null | Record<string, unknown>
 export type RowData = Record<string, CellVal>
 export type TableData = RowData[]

--- a/tests/remote/test_figshare.py
+++ b/tests/remote/test_figshare.py
@@ -407,40 +407,124 @@ def test_publish_article(
 ) -> None:
     """Test publish_article function with different combinations of parameters."""
     article_id = 12345
+    err_msg = "Test error"
 
-    if success:
-        # Mock successful publish
-        with patch(
-            "matbench_discovery.remote.figshare.make_request"
-        ) as mock_make_request:
-            result = figshare.publish_article(article_id, verbose=verbose)
+    def mock_make_request_side_effect(*_args: Any, **_kwargs: Any) -> Any:
+        """Either return successful result or raise exception based on success param."""
+        if success:
+            return  # Successful response for POST
+        raise Exception(err_msg)  # noqa: TRY002
 
-            mock_make_request.assert_called_once_with(
-                "POST", f"{figshare.BASE_URL}/account/articles/{article_id}/publish"
+    with patch(
+        "matbench_discovery.remote.figshare.make_request",
+        side_effect=mock_make_request_side_effect,
+    ):
+        assert figshare.publish_article(article_id, verbose=verbose) is success
+
+        stdout, _ = capsys.readouterr()
+        if success and verbose:
+            expected_url = f"{figshare.ARTICLE_URL_PREFIX}/{article_id}"
+            assert (
+                f"Successfully published article {article_id} at {expected_url}"
+                in stdout
             )
-            assert result is True
-    else:
-        # Mock failed publish
-        with patch(
-            "matbench_discovery.remote.figshare.make_request",
-            side_effect=Exception("API Error"),
-        ) as mock_request:
-            result = figshare.publish_article(article_id, verbose=verbose)
+        elif not success and verbose:
+            assert f"Failed to publish article {article_id}: {err_msg}" in stdout
+        else:
+            assert stdout == ""
 
-            mock_request.assert_called_once()
-            assert result is False
 
-    # Check the captured output based on verbose setting
-    stdout, stderr = capsys.readouterr()
-    assert stderr == ""
+@pytest.mark.parametrize(
+    "filename,existing_files,expected_similar,threshold",
+    [
+        # Empty files case
+        ("models/model1/ver1/file-kappa-103.json.gz", {}, [], 0.7),
+        # Different model family - no match
+        (
+            "models/model1/ver1/file-kappa-103.json.gz",
+            {"models/model2/ver1/file-kappa-103.json.gz": {"id": 123}},
+            [],
+            0.7,
+        ),
+        # Different task type - no match
+        (
+            "models/model1/ver1/file-kappa-103.json.gz",
+            {"models/model1/ver1/file-phonon-50.json.gz": {"id": 123}},
+            [],
+            0.7,
+        ),
+        # Different subfolder - no match
+        (
+            "models/model1/ver1/file-kappa-103.json.gz",
+            {"models/model1/ver2/file-kappa-103.json.gz": {"id": 123}},
+            [],
+            0.7,
+        ),
+        # High similarity, same task - match
+        (
+            "models/model1/ver1/file-kappa-103-v1.json.gz",
+            {"models/model1/ver1/file-kappa-103-v2.json.gz": {"id": 123}},
+            [("models/model1/ver1/file-kappa-103-v2.json.gz", 123)],
+            0.7,
+        ),
+        # Multiple matches
+        (
+            "models/model1/ver1/file-kappa-103.json.gz",
+            {
+                "models/model1/ver1/file1-kappa-103.json.gz": {"id": 123},
+                "models/model1/ver1/file2-kappa-103.json.gz": {"id": 456},
+                "models/model2/ver1/file-kappa-103.json.gz": {"id": 789},
+            },
+            [
+                ("models/model1/ver1/file1-kappa-103.json.gz", 123),
+                ("models/model1/ver1/file2-kappa-103.json.gz", 456),
+            ],
+            0.7,
+        ),
+        # Higher threshold excludes matches
+        (
+            "models/model1/ver1/file-kappa-103.json.gz",
+            {"models/model1/ver1/similar-kappa-103.json.gz": {"id": 123}},
+            [],
+            0.95,
+        ),
+    ],
+)
+def test_find_similar_files(
+    filename: str,
+    existing_files: dict[str, dict[str, Any]],
+    expected_similar: list[tuple[str, int]],
+    threshold: float,
+) -> None:
+    """Test find_similar_files with various scenarios."""
+    with (
+        patch("difflib.SequenceMatcher") as mock_matcher,
+        patch(
+            "matbench_discovery.remote.figshare._extract_task_type"
+        ) as mock_extract_task_type,
+    ):
+        # Configure similarity values
+        mock_seq_matcher = MagicMock()
+        mock_seq_matcher.ratio.return_value = 0.8  # Default high similarity
 
-    if verbose and success:
-        assert (
-            f"Successfully published article {article_id} at "
-            f"{figshare.ARTICLE_URL_PREFIX}/{article_id}" in stdout
+        # For high threshold test
+        if threshold > 0.9:
+            mock_seq_matcher.ratio.return_value = 0.9  # Not enough for 0.95
+
+        mock_matcher.return_value = mock_seq_matcher
+
+        # Configure task type extraction
+        def extract_task(filename: str) -> str:
+            for task in ["kappa", "phonon", "discovery", "geo"]:
+                if task in filename:
+                    return task
+            return ""
+
+        mock_extract_task_type.side_effect = extract_task
+
+        # Run test
+        result = sorted(
+            figshare.find_similar_files(filename, existing_files, threshold),
+            key=lambda x: x[0],
         )
-    elif verbose and not success:
-        assert f"Failed to publish article {article_id}" in stdout
-    else:
-        # If not verbose, there should be no output
-        assert stdout == ""
+        assert result == sorted(expected_similar, key=lambda x: x[0])


### PR DESCRIPTION
this PR standardizes column names and dtypes of all `kappa_SRME` pred files and improves robustness of pred file uploads to figshare

- add `find_similar_files` function to identify likely duplicate files based on similar filename
- update `update_one_modeling_task_article` to check for similar files before uploading, with interactive prompt for deletion
- unit tests for `find_similar_files`
- list deleted files in the upload summary output


also fixes the annoying UX on current landing page that page scrolls from the animated reordering of MetricsTable rows when dragging the RadarChart interrupts the radar drag