### PR TITLE
Add WBM to `dataset.yml` and compute missing_percent of model preds on the fly

### DIFF
--- a/data/datasets.yml
+++ b/data/datasets.yml
@@ -1,3 +1,38 @@
+WBM:
+  name: WBM Benchmark Test Set
+  url: https://github.com/janosh/matbench-discovery/blob/main/data/wbm/readme.md
+  doi: https://doi.org/10.1038/s41524-020-00481-6
+  n_structures: 256_963 # 257_487 before filtering suspicious data, see data/wbm/compile_wbm_test_set.py
+  n_materials: 215_488 # based on number of unique Aflow-style structure prototypes
+  n_stable_materials: 42_825
+  n_uniq_stable_materials: 32_942
+  open: true
+  static: true
+  optimade_api: null
+  native_api: null
+  date_created: 2021-01-01
+  license: CC-BY-4.0
+  description: |
+    Benchmark test set for Matbench Discovery containing 256,963 structures generated via chemical
+    similarity-based elemental substitution of MP source structures followed by DFT relaxation and
+    calculating each structure's formation energy. This is the primary test set used to evaluate
+    model performance on materials discovery tasks.
+  method: DFT
+  params:
+    code: VASP
+    functional: PBE+U
+    pseudopotentials: PBE
+  created_by:
+    - name: Hai-Chen Wang
+      affiliation: Martin-Luther-Universität Halle-Wittenberg, Germany
+    - name: Silvana Botti
+      affiliation: Friedrich-Schiller-Universität Jena, Germany
+      email: silvana.botti@uni-jena.de
+      url: https://wikipedia.org/wiki/Silvana_Botti
+    - name: Miguel A. L. Marques
+      affiliation: Martin-Luther-Universität Halle-Wittenberg, Germany
+      orcid: https://orcid.org/0000-0003-0170-8222
+
 MP 2022:
   name: MP v2022.10.28
   url: https://docs.materialsproject.org/changes/database-versions#v2022.10.28

--- a/data/wbm/compile_wbm_test_set.py
+++ b/data/wbm/compile_wbm_test_set.py
@@ -400,8 +400,8 @@ df_summary["alph_formula"] = [
 ]
 # alphabetical formula and original formula differ due to spaces, number 1 after element
 # symbols (FeO vs Fe1 O1), and element order (FeO vs OFe)
-n_wbm_structs = DATASETS["WBM"]["n_structures"]
-assert sum(df_summary.alph_formula != df_summary[Key.formula]) == n_wbm_structs
+# validate pre-crop state: all formulas should differ from their alphabetical versions
+assert sum(df_summary.alph_formula != df_summary[Key.formula]) == len(df_summary)
 
 df_summary[Key.formula] = df_summary.pop("alph_formula")
 
@@ -515,7 +515,8 @@ df_wbm = df_wbm.loc[df_summary.index]
 
 
 # make sure we dropped the expected number 524 of materials
-assert len(df_summary) == len(df_wbm) == 257_487 - 502 - 22
+n_wbm_structs = DATASETS["WBM"]["n_structures"]
+assert len(df_summary) == len(df_wbm) == n_wbm_structs  # 257_487 - 502 - 22
 
 
 # %%

--- a/data/wbm/compile_wbm_test_set.py
+++ b/data/wbm/compile_wbm_test_set.py
@@ -693,7 +693,7 @@ assert sum(mask_dupe_protos) == 32_784, f"{sum(mask_dupe_protos)=:_}"
 df_summary[MbdKey.uniq_proto] = ~(mask_proto_in_mp | mask_dupe_protos)
 n_wbm_materials = DATASETS["WBM"]["n_materials"]
 assert dict(df_summary[MbdKey.uniq_proto].value_counts()) == {
-    True: n_wbm_materials,  # should be 256_963
+    True: n_wbm_materials,  # should be 215_488
     False: n_wbm_structs - n_wbm_materials,  # should be 41,475
 }
 

--- a/data/wbm/compile_wbm_test_set.py
+++ b/data/wbm/compile_wbm_test_set.py
@@ -26,7 +26,7 @@ from pymatviz.enums import Key
 from tqdm import tqdm
 
 from matbench_discovery import PDF_FIGS, SITE_FIGS, WBM_DIR, today
-from matbench_discovery.data import DataFiles
+from matbench_discovery.data import DATASETS, DataFiles
 from matbench_discovery.energy import calc_energy_from_e_refs, mp_elemental_ref_energies
 from matbench_discovery.enums import MbdKey
 from matbench_discovery.structure import prototype
@@ -400,7 +400,8 @@ df_summary["alph_formula"] = [
 ]
 # alphabetical formula and original formula differ due to spaces, number 1 after element
 # symbols (FeO vs Fe1 O1), and element order (FeO vs OFe)
-assert sum(df_summary.alph_formula != df_summary[Key.formula]) == 257_483
+n_wbm_structs = DATASETS["WBM"]["n_structures"]
+assert sum(df_summary.alph_formula != df_summary[Key.formula]) == n_wbm_structs
 
 df_summary[Key.formula] = df_summary.pop("alph_formula")
 
@@ -689,9 +690,10 @@ assert sum(mask_proto_in_mp) == 11_175, f"{sum(mask_proto_in_mp)=:_}"
 assert sum(mask_dupe_protos) == 32_784, f"{sum(mask_dupe_protos)=:_}"
 
 df_summary[MbdKey.uniq_proto] = ~(mask_proto_in_mp | mask_dupe_protos)
+n_wbm_materials = DATASETS["WBM"]["n_materials"]
 assert dict(df_summary[MbdKey.uniq_proto].value_counts()) == {
-    True: 215_488,
-    False: 41_475,
+    True: n_wbm_materials,  # should be 256_963
+    False: n_wbm_structs - n_wbm_materials,  # should be 41,475
 }
 
 first_uniq_proto_wbm_ids = ["wbm-1-7", "wbm-1-8", "wbm-1-15", "wbm-1-20", "wbm-1-33"]

--- a/data/wbm/eda_wbm.py
+++ b/data/wbm/eda_wbm.py
@@ -15,7 +15,7 @@ from pymatviz.utils import si_fmt_int
 
 from matbench_discovery import PDF_FIGS, ROOT, SITE_FIGS, STABILITY_THRESHOLD
 from matbench_discovery import plots as plots
-from matbench_discovery.data import df_wbm
+from matbench_discovery.data import DATASETS, df_wbm
 from matbench_discovery.energy import mp_elem_ref_entries
 from matbench_discovery.enums import DataFiles, MbdKey
 from matbench_discovery.preds.discovery import df_each_err
@@ -62,11 +62,16 @@ all_counts = (
 
 # %% print prevalence of stable structures in full WBM and uniq-prototypes only
 print(f"{STABILITY_THRESHOLD=}")
-for df, label in (
-    (df_wbm, "full WBM"),
-    (df_wbm.query(MbdKey.uniq_proto), "WBM unique prototypes"),
+for df, label, n_expected in (
+    (df_wbm, "full WBM", DATASETS["WBM"]["n_stable_materials"]),
+    (
+        df_wbm.query(MbdKey.uniq_proto),
+        "WBM unique prototypes",
+        DATASETS["WBM"]["n_uniq_stable_materials"],
+    ),
 ):
     n_stable = sum(df[MbdKey.each_true] <= STABILITY_THRESHOLD)
+    assert n_stable == n_expected, f"{label}: {n_stable=} != {n_expected=}"
     stable_rate = n_stable / len(df)
     print(f"{label}: {stable_rate=:.1%} ({n_stable:,} out of {len(df):,})")
 

--- a/data/wbm/readme.md
+++ b/data/wbm/readme.md
@@ -1,6 +1,6 @@
 # WBM Dataset
 
-The **WBM dataset** was published in [Predicting stable crystalline compounds using chemical similarity][wbm paper] (nat comp mat, Jan 2021). The authors generated 257,487 structures through single-element substitutions on Materials Project (MP) source structures. The replacement element was chosen based on chemical similarity determined by a matrix data-mined from the [Inorganic Crystal Structure Database (ICSD)](https://icsd.products.fiz-karlsruhe.de).
+[The **WBM dataset**](/data/wbm) was published in [Predicting stable crystalline compounds using chemical similarity][wbm paper] (nat comp mat, Jan 2021). The authors generated 257,487 structures through single-element substitutions on Materials Project (MP) source structures. The replacement element was chosen based on chemical similarity determined by a matrix data-mined from the [Inorganic Crystal Structure Database (ICSD)](https://icsd.products.fiz-karlsruhe.de).
 
 The resulting novel structures were relaxed using MP-compatible VASP inputs (i.e. using `pymatgen`'s [`MPRelaxSet`](https://github.com/materialsproject/pymatgen/blob/c4998d92/pymatgen/io/vasp/MPRelaxSet.yaml)) and identical POTCARs in an attempt to create a database of Materials Project compatible novel crystals. Any degradation in model performance from training to test set should therefore largely be a result of extrapolation error rather than covariate shift in the underlying data.
 

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -30,13 +30,17 @@ from pymatviz.enums import Key
 from ruamel.yaml import YAML
 from tqdm import tqdm
 
-from matbench_discovery import TEST_FILES
+from matbench_discovery import DATA_DIR, TEST_FILES
 from matbench_discovery.enums import DataFiles, MbdKey, Model, TestSubset
 
 round_trip_yaml = YAML()  # round-trippable YAML for updating model metadata files
 round_trip_yaml.preserve_quotes = True
 round_trip_yaml.width = 1000  # avoid changing line wrapping
 round_trip_yaml.indent(mapping=2, sequence=4, offset=2)
+
+
+with open(f"{DATA_DIR}/datasets.yml") as file:
+    DATASETS = yaml.safe_load(stream=file)
 
 
 def as_dict_handler(obj: Any) -> dict[str, Any] | None:

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -39,7 +39,7 @@ round_trip_yaml.width = 1000  # avoid changing line wrapping
 round_trip_yaml.indent(mapping=2, sequence=4, offset=2)
 
 
-with open(f"{DATA_DIR}/datasets.yml") as file:
+with open(f"{DATA_DIR}/datasets.yml", encoding="utf-8") as file:
     DATASETS = yaml.safe_load(stream=file)
 
 
@@ -96,7 +96,7 @@ def glob_to_df(
             # .set_index( "material_id" )
             # make sure pred_cols for all models are present in df_mock
             for model in Model:
-                with open(model.yaml_path) as file:
+                with open(model.yaml_path, encoding="utf-8") as file:
                     model_data = yaml.safe_load(file)
 
                 pred_col = (
@@ -270,7 +270,7 @@ def load_df_wbm_with_preds(
 
             df_preds = glob_to_df(model.discovery_path, pbar=False, **kwargs)
 
-            with open(model.yaml_path) as file:
+            with open(model.yaml_path, encoding="utf-8") as file:
                 model_data = yaml.safe_load(file)
 
             pred_col = (
@@ -339,7 +339,7 @@ def update_yaml_file(
     if not re.match(r"^[a-zA-Z0-9-+=_]+(\.[a-zA-Z0-9-+=_]+)*$", dotted_path):
         raise ValueError(f"Invalid {dotted_path=}")
 
-    with open(file_path) as file:
+    with open(file_path, encoding="utf-8") as file:
         yaml_data = round_trip_yaml.load(file)
 
     # Navigate to the correct nested level
@@ -360,7 +360,7 @@ def update_yaml_file(
     current[last] = data
 
     # Write back to file
-    with open(file_path, mode="w") as file:
+    with open(file_path, mode="w", encoding="utf-8") as file:
         round_trip_yaml.dump(yaml_data, file)
 
     return yaml_data

--- a/matbench_discovery/enums.py
+++ b/matbench_discovery/enums.py
@@ -83,7 +83,6 @@ class MbdKey(LabelEnum):
 
     # keep in sync with model-schema.yml
     missing_preds = "missing_preds", "Missing predictions"
-    missing_percent = "missing_percent", "Missing predictions (percent)"
 
     aflow_prototype = "aflow_prototype", "Aflow prototype"
     canonical_proto = "canonical_proto", "Canonical prototype"

--- a/matbench_discovery/enums.py
+++ b/matbench_discovery/enums.py
@@ -370,7 +370,7 @@ class Model(Files, base_dir=f"{ROOT}/models"):
     def metadata(self) -> dict[str, Any]:
         """Metadata associated with the model."""
         yaml_path = f"{type(self).base_dir}/{self.rel_path}"
-        with open(yaml_path) as file:
+        with open(yaml_path, encoding="utf-8") as file:
             data = yaml.safe_load(file)
 
         if not isinstance(data, dict):
@@ -521,7 +521,7 @@ class DataFiles(Files):
         """YAML data associated with the file."""
         yaml_path = f"{PKG_DIR}/data-files.yml"
 
-        with open(yaml_path) as file:
+        with open(yaml_path, encoding="utf-8") as file:
             yaml_data = yaml.safe_load(file)
 
         if self.name not in yaml_data:

--- a/matbench_discovery/metrics/discovery.py
+++ b/matbench_discovery/metrics/discovery.py
@@ -150,7 +150,7 @@ def stable_metrics(
         DAF=precision / prevalence,
         Precision=precision,
         Recall=recall,
-        Accuracy=(n_true_pos + n_true_neg) / len(each_true),
+        Accuracy=(n_true_pos + n_true_neg) / (n_total_pos + n_total_neg),
         **dict(TPR=TPR, FPR=FPR, TNR=TNR, FNR=FNR),
         **dict(TP=n_true_pos, FP=n_false_pos, TN=n_true_neg, FN=n_false_neg),
         MAE=np.abs(each_true - each_pred).mean(),

--- a/matbench_discovery/metrics/discovery.py
+++ b/matbench_discovery/metrics/discovery.py
@@ -183,7 +183,6 @@ def write_metrics_to_yaml(
     # calculate number of missing predictions
     n_missing = int(df_model_preds.isna().sum())
     metrics[str(MbdKey.missing_preds)] = n_missing
-    metrics[str(MbdKey.missing_percent)] = f"{n_missing / len(df_model_preds):.2%}"
 
     # Define metric units for end-of-line comments
     metric_units = {
@@ -199,7 +198,6 @@ def write_metrics_to_yaml(
         "FPR": "fraction",
         "TNR": "fraction",
         "FNR": "fraction",
-        str(MbdKey.missing_percent): "fraction",
         str(MbdKey.missing_preds): "count",
         "TP": "count",
         "FP": "count",
@@ -237,9 +235,7 @@ df_metrics_uniq_protos = (
     .sort_values(by=Key.f1.upper(), ascending=False)
     .T
 )
-df_metrics_uniq_protos = df_metrics_uniq_protos.drop(
-    index=[MbdKey.missing_preds, MbdKey.missing_percent]
-)
+df_metrics_uniq_protos = df_metrics_uniq_protos.drop(index=[MbdKey.missing_preds])
 
 for df, title in (
     (df_metrics, "Metrics for Full Test Set"),

--- a/matbench_discovery/metrics/discovery.py
+++ b/matbench_discovery/metrics/discovery.py
@@ -150,7 +150,11 @@ def stable_metrics(
         DAF=precision / prevalence,
         Precision=precision,
         Recall=recall,
-        Accuracy=(n_true_pos + n_true_neg) / (n_total_pos + n_total_neg),
+        Accuracy=(
+            (n_true_pos + n_true_neg) / (n_total_pos + n_total_neg)
+            if (n_total_pos + n_total_neg > 0)
+            else float("nan")
+        ),
         **dict(TPR=TPR, FPR=FPR, TNR=TNR, FNR=FNR),
         **dict(TP=n_true_pos, FP=n_false_pos, TN=n_true_neg, FN=n_false_neg),
         MAE=np.abs(each_true - each_pred).mean(),

--- a/matbench_discovery/metrics/phonons.py
+++ b/matbench_discovery/metrics/phonons.py
@@ -9,12 +9,11 @@ The metrics include:
   Overpredictions of kappa-contributions from one mode will not cancel against
   underpredictions from another mode.
 
-Code in this module is adapted from https://github.com/MPA2suite/k_SRME/blob/6ff4c867/k_srme/benchmark.py.
-All credit to Balázs Póta, Paramvir Ahlawat, Gábor Csányi, Michele Simoncelli. See
-https://arxiv.org/abs/2408.00755 for details.
+Code in this module is adapted from https://github.com/MPA2suite/k_SRME/blob/6ff4c867/k_srme/benchmark.py,
+published in https://arxiv.org/abs/2408.00755.
 It was ported to this repo in https://github.com/janosh/matbench-discovery/pull/196 to
 implement parallelization across input structures which allows scaling thermal
-conductivity metric to larger test sets.
+conductivity metrics to larger test sets.
 """
 
 import traceback
@@ -24,7 +23,7 @@ import numpy as np
 import pandas as pd
 from pymatviz.enums import Key
 
-from matbench_discovery.enums import MbdKey
+from matbench_discovery.enums import MbdKey, Model
 from matbench_discovery.phonons import thermal_conductivity as ltc
 
 
@@ -231,3 +230,45 @@ def calc_kappa_srme(kappas_pred: pd.Series, kappas_true: pd.Series) -> np.ndarra
 
     denominator = kappas_pred[MbdKey.kappa_tot_avg] + kappas_true[MbdKey.kappa_tot_avg]
     return 2 * microscopic_error / denominator
+
+
+def write_metrics_to_yaml(
+    model: Model, metrics: dict[str, float], pred_file_path: str
+) -> None:
+    """Write kappa metrics to model's YAML file under the phonons section.
+
+    Args:
+        model: Model to write metrics for.
+        metrics: Kappa metrics for this model.
+        pred_file_path: Path to prediction file.
+    """
+    import os
+
+    from ruamel.yaml import YAML
+
+    # Convert absolute path to relative path
+    pred_file_path = pred_file_path.removeprefix(f"{os.getcwd()}/")
+
+    # Update YAML file
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 1000
+    yaml.indent(mapping=2, sequence=4, offset=2)
+
+    with open(model.yaml_path) as file:
+        data = yaml.load(file)
+
+    # Ensure nested structure exists and update non-destructively
+    data.setdefault("metrics", {}).setdefault("phonons", {}).setdefault("kappa_103", {})
+    data["metrics"]["phonons"]["kappa_103"].update(
+        κ_SRME=float(round(metrics["srme"], 4)),
+        κ_SRE=float(round(metrics["sre"], 4)),
+    )
+
+    # Set pred_file if missing
+    if "pred_file" not in data["metrics"]["phonons"]["kappa_103"]:
+        data["metrics"]["phonons"]["kappa_103"]["pred_file"] = pred_file_path
+
+    # Write back to file
+    with open(model.yaml_path, "w") as file:
+        yaml.dump(data, file)

--- a/models/alchembert/alchembert.yml
+++ b/models/alchembert/alchembert.yml
@@ -68,7 +68,6 @@ metrics:
       RMSE: 0.171 # eV/atom
       R2: 0.102 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.603 # fraction
       DAF: 2.821 # dimensionless
@@ -87,7 +86,6 @@ metrics:
       RMSE: 0.334 # eV/atom
       R2: -0.47 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.421 # fraction
       DAF: 2.001 # dimensionless
@@ -106,4 +104,3 @@ metrics:
       RMSE: 0.175 # eV/atom
       R2: 0.096 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/alignn/alignn.yml
+++ b/models/alignn/alignn.yml
@@ -84,7 +84,6 @@ metrics:
       RMSE: 0.154 # eV/atom
       R2: 0.274 # dimensionless
       missing_preds: 1 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.748 # fraction
       DAF: 3.905 # dimensionless
@@ -103,7 +102,6 @@ metrics:
       RMSE: 0.247 # eV/atom
       R2: 0.081 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.567 # fraction
       DAF: 3.206 # dimensionless
@@ -122,4 +120,3 @@ metrics:
       RMSE: 0.154 # eV/atom
       R2: 0.297 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/alphanet/alphanet-mptrj.yml
+++ b/models/alphanet/alphanet-mptrj.yml
@@ -147,7 +147,6 @@ metrics:
       RMSE: 0.091 # eV/atom
       R2: 0.747 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.799 # fraction
       DAF: 4.863 # dimensionless
@@ -166,7 +165,6 @@ metrics:
       RMSE: 0.093 # eV/atom
       R2: 0.745 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.96 # fraction
       DAF: 6.042 # dimensionless
@@ -185,7 +183,6 @@ metrics:
       RMSE: 0.115 # eV/atom
       R2: 0.746 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
   diatomics:
     pred_file: models/alphanet/2025-03-08-diatomics.json.gz
     pred_file_url: https://figshare.com/files/52868972

--- a/models/alphanet/alphanet-v1-oma.yml
+++ b/models/alphanet/alphanet-v1-oma.yml
@@ -145,7 +145,6 @@ metrics:
       RMSE: 0.075 # eV/atom
       R2: 0.827 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.901 # fraction
       DAF: 5.747 # dimensionless
@@ -164,7 +163,6 @@ metrics:
       RMSE: 0.076 # eV/atom
       R2: 0.831 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.982 # fraction
       DAF: 6.312 # dimensionless
@@ -183,6 +181,5 @@ metrics:
       RMSE: 0.074 # eV/atom
       R2: 0.882 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
   diatomics:
     pred_file_url: https://figshare.com/ndownloader/files/54490370

--- a/models/bowsr/bowsr.yml
+++ b/models/bowsr/bowsr.yml
@@ -112,7 +112,6 @@ metrics:
       RMSE: 0.164 # eV/atom
       R2: 0.142 # dimensionless
       missing_preds: 6185 # count
-      missing_percent: 2.41% # fraction
     most_stable_10k:
       F1: 0.664 # fraction
       DAF: 3.252 # dimensionless
@@ -131,7 +130,6 @@ metrics:
       RMSE: 0.32 # eV/atom
       R2: -1.172 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.423 # fraction
       DAF: 1.964 # dimensionless
@@ -150,4 +148,3 @@ metrics:
       RMSE: 0.167 # eV/atom
       R2: 0.151 # dimensionless
       missing_preds: 4484 # count
-      missing_percent: 2.08% # fraction

--- a/models/cgcnn/cgcnn+p.yml
+++ b/models/cgcnn/cgcnn+p.yml
@@ -88,7 +88,6 @@ metrics:
       RMSE: 0.178 # eV/atom
       R2: 0.027 # dimensionless
       missing_preds: 4 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.736 # fraction
       DAF: 3.813 # dimensionless
@@ -107,7 +106,6 @@ metrics:
       RMSE: 0.275 # eV/atom
       R2: -0.076 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.5 # fraction
       DAF: 2.563 # dimensionless
@@ -126,4 +124,3 @@ metrics:
       RMSE: 0.182 # eV/atom
       R2: 0.019 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction

--- a/models/cgcnn/cgcnn.yml
+++ b/models/cgcnn/cgcnn.yml
@@ -85,7 +85,6 @@ metrics:
       RMSE: 0.229 # eV/atom
       R2: -0.624 # dimensionless
       missing_preds: 4 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.745 # fraction
       DAF: 3.88 # dimensionless
@@ -104,7 +103,6 @@ metrics:
       RMSE: 0.23 # eV/atom
       R2: 0.181 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.507 # fraction
       DAF: 2.855 # dimensionless
@@ -123,4 +121,3 @@ metrics:
       RMSE: 0.233 # eV/atom
       R2: -0.603 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction

--- a/models/chgnet/chgnet-0.3.0.yml
+++ b/models/chgnet/chgnet-0.3.0.yml
@@ -126,7 +126,6 @@ metrics:
       RMSE: 0.1 # eV/atom
       R2: 0.69 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.92 # fraction
       DAF: 5.567 # dimensionless
@@ -145,7 +144,6 @@ metrics:
       RMSE: 0.095 # eV/atom
       R2: 0.816 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.613 # fraction
       DAF: 3.361 # dimensionless
@@ -164,4 +162,3 @@ metrics:
       RMSE: 0.103 # eV/atom
       R2: 0.689 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/deepmd/dpa-3.1-3m-ft.yml
+++ b/models/deepmd/dpa-3.1-3m-ft.yml
@@ -152,7 +152,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.862 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.987 # fraction
       DAF: 6.369 # dimensionless
@@ -171,7 +170,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.901 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.884 # fraction
       DAF: 5.667 # dimensionless
@@ -190,4 +188,3 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.869 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/deepmd/dpa-3.1-mptrj.yml
+++ b/models/deepmd/dpa-3.1-mptrj.yml
@@ -150,7 +150,6 @@ metrics:
       RMSE: 0.079 # eV/atom
       R2: 0.809 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.98 # fraction
       DAF: 6.288 # dimensionless
@@ -169,7 +168,6 @@ metrics:
       RMSE: 0.087 # eV/atom
       R2: 0.838 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.803 # fraction
       DAF: 5.024 # dimensionless
@@ -188,4 +186,3 @@ metrics:
       RMSE: 0.08 # eV/atom
       R2: 0.812 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/deepmd/dpa3-v1-mptrj.yml
+++ b/models/deepmd/dpa3-v1-mptrj.yml
@@ -152,7 +152,6 @@ metrics:
       RMSE: 0.082 # eV/atom
       R2: 0.793 # dimensionless
       missing_preds: 14 # count
-      missing_percent: 0.01% # fraction
     most_stable_10k:
       F1: 0.971 # fraction
       DAF: 6.174 # dimensionless
@@ -171,7 +170,6 @@ metrics:
       RMSE: 0.084 # eV/atom
       R2: 0.849 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.765 # fraction
       DAF: 4.654 # dimensionless
@@ -190,4 +188,3 @@ metrics:
       RMSE: 0.083 # eV/atom
       R2: 0.798 # dimensionless
       missing_preds: 11 # count
-      missing_percent: 0.01% # fraction

--- a/models/deepmd/dpa3-v1-openlam.yml
+++ b/models/deepmd/dpa3-v1-openlam.yml
@@ -164,7 +164,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.863 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.987 # fraction
       DAF: 6.371 # dimensionless
@@ -183,7 +182,6 @@ metrics:
       RMSE: 0.066 # eV/atom
       R2: 0.905 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.883 # fraction
       DAF: 5.754 # dimensionless
@@ -202,4 +200,3 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.869 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/deepmd/dpa3-v2-mptrj.yml
+++ b/models/deepmd/dpa3-v2-mptrj.yml
@@ -152,7 +152,6 @@ metrics:
       RMSE: 0.08 # eV/atom
       R2: 0.801 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.98 # fraction
       DAF: 6.28 # dimensionless
@@ -171,7 +170,6 @@ metrics:
       RMSE: 0.078 # eV/atom
       R2: 0.866 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.786 # fraction
       DAF: 4.822 # dimensionless
@@ -190,4 +188,3 @@ metrics:
       RMSE: 0.081 # eV/atom
       R2: 0.804 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/deepmd/dpa3-v2-openlam.yml
+++ b/models/deepmd/dpa3-v2-openlam.yml
@@ -154,7 +154,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.863 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.986 # fraction
       DAF: 6.367 # dimensionless
@@ -173,7 +172,6 @@ metrics:
       RMSE: 0.063 # eV/atom
       R2: 0.913 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.89 # fraction
       DAF: 5.747 # dimensionless
@@ -192,4 +190,3 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.869 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/eSEN/eSEN-30m-mp.yml
+++ b/models/eSEN/eSEN-30m-mp.yml
@@ -118,7 +118,6 @@ metrics:
       RMSE: 0.077 # eV/atom
       R2: 0.818 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.831 # fraction
       DAF: 5.26 # dimensionless
@@ -137,7 +136,6 @@ metrics:
       RMSE: 0.078 # eV/atom
       R2: 0.822 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.978 # fraction
       DAF: 6.261 # dimensionless
@@ -156,4 +154,3 @@ metrics:
       RMSE: 0.111 # eV/atom
       R2: 0.755 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/eSEN/eSEN-30m-oam.yml
+++ b/models/eSEN/eSEN-30m-oam.yml
@@ -118,7 +118,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.86 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.925 # fraction
       DAF: 6.069 # dimensionless
@@ -137,7 +136,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.866 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.985 # fraction
       DAF: 6.35 # dimensionless
@@ -156,4 +154,3 @@ metrics:
       RMSE: 0.068 # eV/atom
       R2: 0.898 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/eqV2/eqV2-m-omat-salex-mp.yml
+++ b/models/eqV2/eqV2-m-omat-salex-mp.yml
@@ -144,7 +144,6 @@ metrics:
       RMSE: 0.071 # eV/atom
       R2: 0.842 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.988 # fraction
       DAF: 6.382 # dimensionless
@@ -163,7 +162,6 @@ metrics:
       RMSE: 0.066 # eV/atom
       R2: 0.904 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.917 # fraction
       DAF: 6.047 # dimensionless
@@ -182,4 +180,3 @@ metrics:
       RMSE: 0.072 # eV/atom
       R2: 0.848 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/eqV2/eqV2-s-dens-mp.yml
+++ b/models/eqV2/eqV2-s-dens-mp.yml
@@ -146,7 +146,6 @@ metrics:
       RMSE: 0.084 # eV/atom
       R2: 0.785 # dimensionless
       missing_preds: 351 # count
-      missing_percent: 0.14% # fraction
     most_stable_10k:
       F1: 0.983 # fraction
       DAF: 6.326 # dimensionless
@@ -165,7 +164,6 @@ metrics:
       RMSE: 0.091 # eV/atom
       R2: 0.823 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.815 # fraction
       DAF: 5.042 # dimensionless
@@ -184,4 +182,3 @@ metrics:
       RMSE: 0.085 # eV/atom
       R2: 0.788 # dimensionless
       missing_preds: 309 # count
-      missing_percent: 0.14% # fraction

--- a/models/eqnorm/eqnorm-mptrj.yml
+++ b/models/eqnorm/eqnorm-mptrj.yml
@@ -151,7 +151,6 @@ metrics:
       RMSE: 0.081 # eV/atom
       R2: 0.796 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.786 # fraction
       DAF: 4.844 # dimensionless
@@ -170,7 +169,6 @@ metrics:
       RMSE: 0.083 # eV/atom
       R2: 0.799 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.97 # fraction
       DAF: 6.156 # dimensionless
@@ -189,4 +187,3 @@ metrics:
       RMSE: 0.105 # eV/atom
       R2: 0.775 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/esnet/esnet.yml
+++ b/models/esnet/esnet.yml
@@ -94,7 +94,6 @@ metrics:
       RMSE: 0.193 # eV/atom
       R2: -0.148 # dimensionless
       missing_preds: 1 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.879 # fraction
       DAF: 5.132 # dimensionless
@@ -113,7 +112,6 @@ metrics:
       RMSE: 0.113 # eV/atom
       R2: 0.754 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.572 # fraction
       DAF: 3.498 # dimensionless
@@ -132,4 +130,3 @@ metrics:
       RMSE: 0.194 # eV/atom
       R2: -0.114 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/gnome/gnome.yml
+++ b/models/gnome/gnome.yml
@@ -93,7 +93,6 @@ metrics:
       RMSE: 0.083 # eV/atom
       R2: 0.786 # dimensionless
       missing_preds: 1744 # count
-      missing_percent: 0.68% # fraction
     most_stable_10k:
       F1: 0.967 # fraction
       DAF: 6.127 # dimensionless
@@ -112,7 +111,6 @@ metrics:
       RMSE: 0.089 # eV/atom
       R2: 0.836 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.829 # fraction
       DAF: 5.523 # dimensionless
@@ -131,4 +129,3 @@ metrics:
       RMSE: 0.085 # eV/atom
       R2: 0.785 # dimensionless
       missing_preds: 1517 # count
-      missing_percent: 0.70% # fraction

--- a/models/grace/grace-1l-oam.yml
+++ b/models/grace/grace-1l-oam.yml
@@ -112,7 +112,6 @@ metrics:
       RMSE: 0.073 # eV/atom
       R2: 0.836 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.962 # fraction
       DAF: 6.063 # dimensionless
@@ -131,7 +130,6 @@ metrics:
       RMSE: 0.087 # eV/atom
       R2: 0.843 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.824 # fraction
       DAF: 5.255 # dimensionless
@@ -150,4 +148,3 @@ metrics:
       RMSE: 0.073 # eV/atom
       R2: 0.842 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/grace/grace-2l-mptrj.yml
+++ b/models/grace/grace-2l-mptrj.yml
@@ -109,7 +109,6 @@ metrics:
       RMSE: 0.092 # eV/atom
       R2: 0.74 # dimensionless
       missing_preds: 128 # count
-      missing_percent: 0.05% # fraction
     most_stable_10k:
       F1: 0.914 # fraction
       DAF: 5.503 # dimensionless
@@ -128,7 +127,6 @@ metrics:
       RMSE: 0.133 # eV/atom
       R2: 0.641 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.691 # fraction
       DAF: 4.163 # dimensionless
@@ -147,7 +145,6 @@ metrics:
       RMSE: 0.094 # eV/atom
       R2: 0.741 # dimensionless
       missing_preds: 110 # count
-      missing_percent: 0.05% # fraction
   diatomics:
     pred_file: models/grace/grace-2l-mptrj/2025-02-19-diatomics.json.gz
     pred_file_url: https://figshare.com/files/52467524

--- a/models/grace/grace-2l-oam.yml
+++ b/models/grace/grace-2l-oam.yml
@@ -112,7 +112,6 @@ metrics:
       RMSE: 0.068 # eV/atom
       R2: 0.856 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.985 # fraction
       DAF: 6.352 # dimensionless
@@ -131,7 +130,6 @@ metrics:
       RMSE: 0.081 # eV/atom
       R2: 0.861 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.88 # fraction
       DAF: 5.774 # dimensionless
@@ -150,7 +148,6 @@ metrics:
       RMSE: 0.068 # eV/atom
       R2: 0.862 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
   diatomics:
     pred_file: models/grace/grace-2l-oam/2025-02-19-diatomics.json.gz
     pred_file_url: https://figshare.com/files/52467527

--- a/models/hienet/hienet.yml
+++ b/models/hienet/hienet.yml
@@ -145,7 +145,6 @@ metrics:
       RMSE: 0.082 # eV/atom
       R2: 0.791 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.973 # fraction
       DAF: 6.194 # dimensionless
@@ -164,7 +163,6 @@ metrics:
       RMSE: 0.069 # eV/atom
       R2: 0.894 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.777 # fraction
       DAF: 4.932 # dimensionless
@@ -183,4 +181,3 @@ metrics:
       RMSE: 0.084 # eV/atom
       R2: 0.793 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/m3gnet/m3gnet.yml
+++ b/models/m3gnet/m3gnet.yml
@@ -117,7 +117,6 @@ metrics:
       RMSE: 0.115 # eV/atom
       R2: 0.588 # dimensionless
       missing_preds: 355 # count
-      missing_percent: 0.14% # fraction
     most_stable_10k:
       F1: 0.868 # fraction
       DAF: 5.02 # dimensionless
@@ -136,7 +135,6 @@ metrics:
       RMSE: 0.158 # eV/atom
       R2: 0.551 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.569 # fraction
       DAF: 2.882 # dimensionless
@@ -155,4 +153,3 @@ metrics:
       RMSE: 0.118 # eV/atom
       R2: 0.585 # dimensionless
       missing_preds: 299 # count
-      missing_percent: 0.14% # fraction

--- a/models/mace/mace-mp-0.yml
+++ b/models/mace/mace-mp-0.yml
@@ -128,7 +128,6 @@ metrics:
       RMSE: 0.099 # eV/atom
       R2: 0.698 # dimensionless
       missing_preds: 38 # count
-      missing_percent: 0.01% # fraction
     most_stable_10k:
       F1: 0.888 # fraction
       DAF: 5.221 # dimensionless
@@ -147,7 +146,6 @@ metrics:
       RMSE: 0.165 # eV/atom
       R2: 0.508 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.669 # fraction
       DAF: 3.777 # dimensionless
@@ -166,7 +164,6 @@ metrics:
       RMSE: 0.101 # eV/atom
       R2: 0.697 # dimensionless
       missing_preds: 34 # count
-      missing_percent: 0.02% # fraction
   diatomics:
     pred_file: models/mace/mace-mp-0/2025-02-13-diatomics.json.gz
     pred_file_url: https://figshare.com/files/52449434

--- a/models/mace/mace-mpa-0.yml
+++ b/models/mace/mace-mpa-0.yml
@@ -127,7 +127,6 @@ metrics:
       RMSE: 0.073 # eV/atom
       R2: 0.837 # dimensionless
       missing_preds: 4 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.978 # fraction
       DAF: 6.258 # dimensionless
@@ -146,7 +145,6 @@ metrics:
       RMSE: 0.105 # eV/atom
       R2: 0.776 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.852 # fraction
       DAF: 5.582 # dimensionless
@@ -165,7 +163,6 @@ metrics:
       RMSE: 0.073 # eV/atom
       R2: 0.842 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
   diatomics:
     pred_file: models/mace/mace-mpa-0/2025-02-13-diatomics.json.gz
     pred_file_url: https://figshare.com/files/52449437

--- a/models/matris/matris-v050-mptrj.yml
+++ b/models/matris/matris-v050-mptrj.yml
@@ -138,7 +138,6 @@ metrics:
       RMSE: 0.08 # eV/atom
       R2: 0.8 # dimensionless
       missing_preds: 6 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.984 # fraction
       DAF: 6.341 # dimensionless
@@ -157,7 +156,6 @@ metrics:
       RMSE: 0.057 # eV/atom
       R2: 0.926 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.809 # fraction
       DAF: 5.049 # dimensionless
@@ -176,4 +174,3 @@ metrics:
       RMSE: 0.082 # eV/atom
       R2: 0.803 # dimensionless
       missing_preds: 4 # count
-      missing_percent: 0.00% # fraction

--- a/models/mattersim/mattersim-v1-5M.yml
+++ b/models/mattersim/mattersim-v1-5M.yml
@@ -181,7 +181,6 @@ metrics:
       RMSE: 0.069 # eV/atom
       R2: 0.854 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.984 # fraction
       DAF: 6.339 # dimensionless
@@ -200,7 +199,6 @@ metrics:
       RMSE: 0.078 # eV/atom
       R2: 0.869 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.862 # fraction
       DAF: 5.852 # dimensionless
@@ -219,7 +217,6 @@ metrics:
       RMSE: 0.068 # eV/atom
       R2: 0.863 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
   diatomics:
     pred_file: models/mattersim/mattersim-v1-5M/2025-02-19-diatomics.json.gz
     pred_file_url: https://figshare.com/files/52468178

--- a/models/megnet/megnet.yml
+++ b/models/megnet/megnet.yml
@@ -92,7 +92,6 @@ metrics:
       RMSE: 0.204 # eV/atom
       R2: -0.277 # dimensionless
       missing_preds: 1 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.632 # fraction
       DAF: 3.022 # dimensionless
@@ -111,7 +110,6 @@ metrics:
       RMSE: 0.336 # eV/atom
       R2: -0.908 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.51 # fraction
       DAF: 2.959 # dimensionless
@@ -130,4 +128,3 @@ metrics:
       RMSE: 0.206 # eV/atom
       R2: -0.248 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/nequix/nequix-mp-1.yml
+++ b/models/nequix/nequix-mp-1.yml
@@ -149,7 +149,6 @@ metrics:
       RMSE: 0.084 # eV/atom
       R2: 0.78 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.751 # fraction
       DAF: 4.455 # dimensionless
@@ -168,7 +167,6 @@ metrics:
       RMSE: 0.086 # eV/atom
       R2: 0.782 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.953 # fraction
       DAF: 5.949 # dimensionless
@@ -187,4 +185,3 @@ metrics:
       RMSE: 0.117 # eV/atom
       R2: 0.734 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/orb/orb-v2-mptrj.yml
+++ b/models/orb/orb-v2-mptrj.yml
@@ -133,7 +133,6 @@ metrics:
       RMSE: 0.09 # eV/atom
       R2: 0.752 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.971 # fraction
       DAF: 6.173 # dimensionless
@@ -152,7 +151,6 @@ metrics:
       RMSE: 0.098 # eV/atom
       R2: 0.801 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.765 # fraction
       DAF: 4.702 # dimensionless
@@ -171,4 +169,3 @@ metrics:
       RMSE: 0.091 # eV/atom
       R2: 0.756 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/orb/orb-v2.yml
+++ b/models/orb/orb-v2.yml
@@ -137,7 +137,6 @@ metrics:
       RMSE: 0.078 # eV/atom
       R2: 0.814 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.985 # fraction
       DAF: 6.348 # dimensionless
@@ -156,7 +155,6 @@ metrics:
       RMSE: 0.068 # eV/atom
       R2: 0.897 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.88 # fraction
       DAF: 6.041 # dimensionless
@@ -175,4 +173,3 @@ metrics:
       RMSE: 0.077 # eV/atom
       R2: 0.824 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/orb/orb-v3.yml
+++ b/models/orb/orb-v3.yml
@@ -137,7 +137,6 @@ metrics:
       RMSE: 0.076 # eV/atom
       R2: 0.82 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.982 # fraction
       DAF: 6.307 # dimensionless
@@ -156,7 +155,6 @@ metrics:
       RMSE: 0.08 # eV/atom
       R2: 0.86 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.905 # fraction
       DAF: 5.912 # dimensionless
@@ -175,4 +173,3 @@ metrics:
       RMSE: 0.078 # eV/atom
       R2: 0.821 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/sevennet/sevennet-0.yml
+++ b/models/sevennet/sevennet-0.yml
@@ -136,7 +136,6 @@ metrics:
       RMSE: 0.09 # eV/atom
       R2: 0.75 # dimensionless
       missing_preds: 3 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.945 # fraction
       DAF: 5.857 # dimensionless
@@ -155,7 +154,6 @@ metrics:
       RMSE: 0.124 # eV/atom
       R2: 0.7 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.724 # fraction
       DAF: 4.252 # dimensionless
@@ -174,4 +172,3 @@ metrics:
       RMSE: 0.092 # eV/atom
       R2: 0.75 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/sevennet/sevennet-l3i5.yml
+++ b/models/sevennet/sevennet-l3i5.yml
@@ -134,7 +134,6 @@ metrics:
       RMSE: 0.086 # eV/atom
       R2: 0.773 # dimensionless
       missing_preds: 3 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.952 # fraction
       DAF: 5.945 # dimensionless
@@ -153,7 +152,6 @@ metrics:
       RMSE: 0.114 # eV/atom
       R2: 0.745 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.76 # fraction
       DAF: 4.629 # dimensionless
@@ -172,4 +170,3 @@ metrics:
       RMSE: 0.087 # eV/atom
       R2: 0.776 # dimensionless
       missing_preds: 1 # count
-      missing_percent: 0.00% # fraction

--- a/models/sevennet/sevennet-mf-ompa.yml
+++ b/models/sevennet/sevennet-mf-ompa.yml
@@ -149,7 +149,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.867 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     full_test_set:
       F1: 0.884 # fraction
       DAF: 5.082 # dimensionless
@@ -168,7 +167,6 @@ metrics:
       RMSE: 0.067 # eV/atom
       R2: 0.861 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.985 # fraction
       DAF: 6.346 # dimensionless
@@ -187,4 +185,3 @@ metrics:
       RMSE: 0.071 # eV/atom
       R2: 0.888 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction

--- a/models/voronoi_rf/voronoi-rf.yml
+++ b/models/voronoi_rf/voronoi-rf.yml
@@ -80,7 +80,6 @@ metrics:
       RMSE: 0.206 # eV/atom
       R2: -0.316 # dimensionless
       missing_preds: 19 # count
-      missing_percent: 0.01% # fraction
     most_stable_10k:
       F1: 0.551 # fraction
       DAF: 2.487 # dimensionless
@@ -99,7 +98,6 @@ metrics:
       RMSE: 0.417 # eV/atom
       R2: -1.012 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.333 # fraction
       DAF: 1.579 # dimensionless
@@ -118,4 +116,3 @@ metrics:
       RMSE: 0.212 # eV/atom
       R2: -0.329 # dimensionless
       missing_preds: 2 # count
-      missing_percent: 0.00% # fraction

--- a/models/wrenformer/wrenformer.yml
+++ b/models/wrenformer/wrenformer.yml
@@ -86,7 +86,6 @@ metrics:
       RMSE: 0.182 # eV/atom
       R2: -0.02 # dimensionless
       missing_preds: 7 # count
-      missing_percent: 0.00% # fraction
     most_stable_10k:
       F1: 0.721 # fraction
       DAF: 3.691 # dimensionless
@@ -105,7 +104,6 @@ metrics:
       RMSE: 0.239 # eV/atom
       R2: 0.138 # dimensionless
       missing_preds: 0 # count
-      missing_percent: 0.00% # fraction
     unique_prototypes:
       F1: 0.466 # fraction
       DAF: 2.256 # dimensionless
@@ -124,4 +122,3 @@ metrics:
       RMSE: 0.186 # eV/atom
       R2: -0.018 # dimensionless
       missing_preds: 5 # count
-      missing_percent: 0.00% # fraction

--- a/scripts/evals/discovery.py
+++ b/scripts/evals/discovery.py
@@ -19,8 +19,8 @@ from pymatviz.enums import Key, eV_per_atom
 from pymatviz.utils import si_fmt
 from sklearn.dummy import DummyClassifier
 
-from matbench_discovery import DATA_DIR, PKG_DIR
-from matbench_discovery.data import df_wbm
+from matbench_discovery import PKG_DIR
+from matbench_discovery.data import DATASETS, df_wbm
 from matbench_discovery.enums import DataFiles, MbdKey, Model, Open, Targets, TestSubset
 from matbench_discovery.metrics import discovery
 
@@ -73,9 +73,6 @@ model_name_col = "Model"
 non_compliant_models = [
     model.label for model in Model if model.is_complete and not model.is_compliant
 ]
-
-with open(f"{DATA_DIR}/datasets.yml") as file:
-    DATASETS = yaml.safe_load(file)
 
 # Add model metadata to df_metrics(_10k|_uniq_protos)
 models = discovery.df_metrics_uniq_protos.columns

--- a/scripts/evals/discovery.py
+++ b/scripts/evals/discovery.py
@@ -8,7 +8,6 @@ the site.
 
 # %%
 import itertools
-import sys
 from datetime import date
 
 import numpy as np
@@ -20,6 +19,7 @@ from pymatviz.utils import si_fmt
 from sklearn.dummy import DummyClassifier
 
 from matbench_discovery import PKG_DIR
+from matbench_discovery.cli import cli_args
 from matbench_discovery.data import DATASETS, df_wbm
 from matbench_discovery.enums import DataFiles, MbdKey, Model, Open, Targets, TestSubset
 from matbench_discovery.metrics import discovery
@@ -34,28 +34,33 @@ if __name__ == "__main__":
 
     uniq_protos_idx = df_wbm.query(MbdKey.uniq_proto).index
 
-    models_to_write = [
-        Model[model] for model in sys.argv[1:] if hasattr(Model, model)
-    ] or Model
+    models_to_write = cli_args.models or list(Model)
+
     for model in models_to_write:
-        model_preds = preds.df_preds[model.label]
-        for test_subset, (metrics, subset_idx) in {
-            TestSubset.full_test_set: (
-                preds.df_metrics[model.label].to_dict(),
-                slice(None),
-            ),
-            TestSubset.uniq_protos: (
-                preds.df_metrics_uniq_protos[model.label].to_dict(),
-                uniq_protos_idx,
-            ),
-            TestSubset.most_stable_10k: (
-                preds.df_metrics_10k[model.label].to_dict(),
-                model_preds.loc[uniq_protos_idx].nsmallest(10_000).index,
-            ),
-        }.items():
-            discovery.write_metrics_to_yaml(
-                model, metrics, model_preds.loc[subset_idx], test_subset
-            )
+        try:
+            print(f"\nProcessing {model.label}...")
+            model_preds = preds.df_preds[model.label]
+            for test_subset, (metrics, subset_idx) in {
+                TestSubset.full_test_set: (
+                    preds.df_metrics[model.label].to_dict(),
+                    slice(None),
+                ),
+                TestSubset.uniq_protos: (
+                    preds.df_metrics_uniq_protos[model.label].to_dict(),
+                    uniq_protos_idx,
+                ),
+                TestSubset.most_stable_10k: (
+                    preds.df_metrics_10k[model.label].to_dict(),
+                    model_preds.loc[uniq_protos_idx].nsmallest(10_000).index,
+                ),
+            }.items():
+                discovery.write_metrics_to_yaml(
+                    model, metrics, model_preds.loc[subset_idx], test_subset
+                )
+            print(f"\t✓ Updated discovery metrics for {test_subset}")
+        except Exception as exc:
+            print(f"\t✗ Error processing {model.label}: {exc}")
+            continue
 
     if not pmv.IS_IPYTHON:
         raise SystemExit(0)
@@ -262,7 +267,7 @@ for df_in, df_out, col in (
 
 
 # %%
-with open(f"{PKG_DIR}/modeling-tasks.yml") as file:
+with open(f"{PKG_DIR}/modeling-tasks.yml", encoding="utf-8") as file:
     discovery_metrics = yaml.safe_load(file)["discovery"]["metrics"]
 
 R2_col = "R<sup>2</sup>"

--- a/scripts/upload_model_preds_to_figshare.py
+++ b/scripts/upload_model_preds_to_figshare.py
@@ -20,7 +20,7 @@ from matbench_discovery.cli import cli_parser
 from matbench_discovery.data import round_trip_yaml
 from matbench_discovery.enums import Model
 
-with open(f"{PKG_DIR}/modeling-tasks.yml") as file:
+with open(f"{PKG_DIR}/modeling-tasks.yml", encoding="utf-8") as file:
     MODELING_TASKS: Final = yaml.safe_load(file)
     # remove 'cps' task as it's a dynamic metric with changing weights
     # no point in uploading to figshare

--- a/scripts/upload_model_preds_to_figshare.py
+++ b/scripts/upload_model_preds_to_figshare.py
@@ -51,7 +51,7 @@ def process_exclusion_prefixes(items: list[str], all_items: list[str]) -> list[s
     return result
 
 
-def get_article_metadata(task_info: dict[str, str]) -> dict[str, Sequence[object]]:
+def get_article_metadata(task_info: dict[str, Any]) -> dict[str, Sequence[object]]:
     """Get metadata for creating a new Figshare article for a modeling task."""
     return {
         "title": f"Matbench Discovery - Model Predictions for {task_info['label']}",
@@ -88,6 +88,11 @@ def update_one_modeling_task_article(
     interactive: bool = True,
 ) -> None:
     """Update or create a Figshare article for a modeling task."""
+    if (task_info := modeling_tasks.get(task)) is None:
+        raise KeyError(
+            f"Missing task metadata for {task!r}. "
+            f"Available tasks: {list(modeling_tasks)}"
+        )
     article_id = figshare.ARTICLE_IDS[f"model_preds_{task}"]
     article_is_new = False
 
@@ -104,7 +109,7 @@ def update_one_modeling_task_article(
             print(f"\nWould create new article for {task=}")
             article_id = 0
         else:
-            metadata = get_article_metadata(modeling_tasks[task])
+            metadata = get_article_metadata(task_info)
             article_id = figshare.create_article(metadata)
             article_is_new = True
             print(
@@ -169,7 +174,7 @@ def update_one_modeling_task_article(
                 )
                 continue
 
-            filename = file_path.removeprefix(f"{ROOT}{os.sep}")
+            filename = str(os.path.relpath(file_path, ROOT))
 
             # First check if the exact same file already exists
             if not force_reupload and not dry_run:

--- a/scripts/upload_model_preds_to_figshare.py
+++ b/scripts/upload_model_preds_to_figshare.py
@@ -9,7 +9,7 @@ ML-relaxed structures, and symmetry analysis files.
 import os
 import tomllib
 from collections.abc import Sequence
-from typing import Any, Final, Literal
+from typing import Any, Literal
 
 import yaml
 from tqdm import tqdm
@@ -21,10 +21,10 @@ from matbench_discovery.data import round_trip_yaml
 from matbench_discovery.enums import Model
 
 with open(f"{PKG_DIR}/modeling-tasks.yml", encoding="utf-8") as file:
-    MODELING_TASKS: Final = yaml.safe_load(file)
-    # remove 'cps' task as it's a dynamic metric with changing weights
-    # no point in uploading to figshare
-    MODELING_TASKS.pop("cps", None)
+    MODELING_TASKS = yaml.safe_load(file)
+# remove 'cps' task as it's a dynamic metric with changing weights
+# no point in uploading to figshare
+MODELING_TASKS.pop("cps", None)
 
 with open(f"{ROOT}/pyproject.toml", mode="rb") as toml_file:
     pyproject = tomllib.load(toml_file)["project"]
@@ -175,7 +175,7 @@ def update_one_modeling_task_article(
                 )
                 continue
 
-            filename = file_path.removeprefix(f"{ROOT}/")
+            filename = file_path.removeprefix(f"{ROOT}{os.sep}")
 
             # First check if the exact same file already exists
             if not force_reupload and not dry_run:
@@ -217,6 +217,8 @@ def update_one_modeling_task_article(
                                 article_id, similar_id
                             ):
                                 deleted_files[similar_name] = similar_id
+                                # keep local view in sync to classify uploads correctly
+                                existing_files.pop(similar_name, None)
                                 print(f"Deleted similar file: {similar_name}")
                 else:
                     print("Skipping deletion of similar files (non-interactive mode)")
@@ -377,7 +379,7 @@ def main(raw_args: Sequence[str] | None = None) -> int:
         except Exception as exc:  # prompt to delete article if something went wrong
             state = {
                 key: locals().get(key)
-                for key in ("task", "model_name", "models_to_update", "tasks_to_update")
+                for key in ("task", "models_to_update", "tasks_to_update")
             }
             exc.add_note(f"Upload failed with {state=}")
             raise

--- a/site/src/lib/HeatmapTable.svelte
+++ b/site/src/lib/HeatmapTable.svelte
@@ -318,6 +318,7 @@
     grid-column: 2;
     width: 100%;
     display: flex;
+    place-items: center;
     margin: 10pt auto;
     gap: 2em;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);

--- a/site/src/lib/ModelCard.svelte
+++ b/site/src/lib/ModelCard.svelte
@@ -35,7 +35,7 @@
       : {}),
     CPS: model.CPS,
   })
-  let { missing_preds, missing_percent } = $derived(all_metrics)
+  let { missing_preds } = $derived(all_metrics)
 
   let links = $derived(
     [
@@ -120,10 +120,15 @@
       </span>
     </span>
   {/if}
-  <span>
+  <span
+    {@attach tooltip()}
+    title="Out of {format_num(DATASETS.WBM.n_structures, `,`)} WBM structures, {format_num(missing_preds ?? 0, `,`)} are missing predictions. This refers only to the discovery task of predicting WBM convex hull distances."
+  >
     <Icon icon="MissingMetadata" /> Missing preds:
     {format_num(missing_preds ?? 0, `,.0f`)}
-    <small>({missing_percent})</small>
+    {#if missing_preds && missing_preds > 0}
+      <small>({format_num(missing_preds / DATASETS.WBM.n_structures, `.3~%`)})</small>
+    {/if}
   </span>
 </section>
 {#if show_details}
@@ -148,7 +153,7 @@
       <h3>Package versions</h3>
       <ul>
         {#each Object.entries(model.requirements ?? {}) as [name, version] (name)}
-          {@const [href, link_text] = version.startsWith(`http`)
+          {@const [href, link_text] = version?.startsWith(`http`)
           // version.split(`/`).at(-1) assumes final part after / of URL is the package version, as is the case for GitHub releases
           ? [version, version.split(`/`).at(-1)]
           : [`https://pypi.org/project/${name}/${version}`, version]}

--- a/site/src/lib/dataset-schema.d.ts
+++ b/site/src/lib/dataset-schema.d.ts
@@ -123,6 +123,14 @@ export interface Dataset {
    */
   n_materials?: number
   /**
+   * Number of stable materials in the dataset
+   */
+  n_stable_materials?: number
+  /**
+   * Number of unique stable materials in the dataset
+   */
+  n_uniq_stable_materials?: number
+  /**
    * Chemical elements included in the dataset (either symbols or atomic numbers)
    */
   elements?: (string | number)[]

--- a/site/src/lib/label-schema.d.ts
+++ b/site/src/lib/label-schema.d.ts
@@ -156,7 +156,6 @@ export interface MetadataLabels {
   checkpoint_license: Label1
   code_license: Label1
   missing_preds: Label1
-  missing_percent: Label1
   'Run Time (h)': Label1
   org: Label1
 }

--- a/site/src/lib/labels.ts
+++ b/site/src/lib/labels.ts
@@ -172,12 +172,6 @@ export const METADATA_COLS: MetadataLabels = {
     description: `Number of missing predictions`,
     visible: false,
   },
-  missing_percent: {
-    key: `missing_percent`,
-    label: `Missing %`,
-    description: `Percentage of missing predictions`,
-    visible: false,
-  },
   'Run Time (h)': {
     key: `run_time_h`,
     label: `Run Time`,

--- a/site/src/lib/model-schema.d.ts
+++ b/site/src/lib/model-schema.d.ts
@@ -273,22 +273,21 @@ export interface PhononMetrics {
  * via the `definition` "DiscoveryMetricsSet".
  */
 export interface DiscoveryMetricsSet {
-  F1?: number
-  DAF?: number
-  Precision?: number
-  Recall?: number
-  Accuracy?: number
-  TPR?: number
-  FPR?: number
-  TNR?: number
-  FNR?: number
-  TP?: number
-  FP?: number
-  TN?: number
-  FN?: number
-  MAE?: number
-  RMSE?: number
-  R2?: number
-  missing_preds?: number
-  missing_percent?: string
+  F1: number
+  DAF: number
+  Precision: number
+  Recall: number
+  Accuracy: number
+  TPR: number
+  FPR: number
+  TNR: number
+  FNR: number
+  TP: number
+  FP: number
+  TN: number
+  FN: number
+  MAE: number
+  RMSE: number
+  R2: number
+  missing_preds: number
 }

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
   import type { DiscoverySet, ModelData } from '$lib'
-  import { DynamicScatter, Icon, MetricsTable, RadarChart, SelectToggle } from '$lib'
+  import {
+    DATASETS,
+    DynamicScatter,
+    Icon,
+    MetricsTable,
+    RadarChart,
+    SelectToggle,
+  } from '$lib'
   import { CPS_CONFIG } from '$lib/combined_perf_score.svelte'
   import { ALL_METRICS, DISCOVERY_SET_LABELS, METADATA_COLS } from '$lib/labels'
   import { model_is_compliant, MODELS } from '$lib/models.svelte'
@@ -18,7 +25,7 @@
   import type { Snapshot } from './$types'
 
   let n_wbm_stable_uniq_protos = 32_942
-  let n_wbm_uniq_protos = 215_488
+  let n_wbm_uniq_protos = DATASETS.WBM.n_materials
 
   let table = $state({
     show_non_compliant: true,

--- a/site/src/routes/data/[slug]/+page.svelte
+++ b/site/src/routes/data/[slug]/+page.svelte
@@ -11,7 +11,7 @@
   }
   let { data }: Props = $props()
   const { dataset } = data
-  const ext_link_props = { target: `_blank`, rel: `noopener noreferrer` }
+  const link_props = { target: `_blank`, rel: `noopener noreferrer` }
 
   let days_created = calculate_days_ago(dataset.date_created)
   let days_added = calculate_days_ago(dataset.date_added ?? ``)
@@ -34,69 +34,49 @@
 
 <section class="meta-info">
   {#if dataset.version}
-    <div>Version: {dataset.version}</div>
+    <span>Version: {dataset.version}</span>
   {/if}
 
-  <div>
-    <Icon icon="Calendar" />
-    Created: <span title="{days_created} days ago" {@attach tooltip()}>
-      {format_date(dataset.date_created)}
-    </span>
-  </div>
+  <span title="{days_created} days ago" {@attach tooltip()}>
+    <Icon icon="Calendar" /> Created: {format_date(dataset.date_created)}
+  </span>
 
   {#if dataset.date_added}
-    <div>
-      <Icon icon="CalendarPlus" />
-      Added: <span title="{days_added} days ago" {@attach tooltip()}>
-        {format_date(dataset.date_added)}
-      </span>
-    </div>
+    <span title="{days_added} days ago" {@attach tooltip()}>
+      <Icon icon="CalendarPlus" /> Added: {format_date(dataset.date_added)}
+    </span>
   {/if}
 
-  <div>
-    <Icon icon="Database" />
-    <span title={dataset.n_structures.toLocaleString()} {@attach tooltip()}>
-      {format_num(dataset.n_structures, `.3~s`)}
-    </span> structures
-  </div>
+  <span title={dataset.n_structures.toLocaleString()} {@attach tooltip()}>
+    <Icon icon="Database" /> {format_num(dataset.n_structures, `.3~s`)} structures
+  </span>
 
   {#if dataset.n_materials}
-    <div>
-      <Icon icon="Lattice" />
-      <span title={dataset.n_materials.toLocaleString()} {@attach tooltip()}>
-        {format_num(dataset.n_materials, `.3~s`)}
-      </span> materials
-    </div>
+    <span title={dataset.n_materials.toLocaleString()} {@attach tooltip()}>
+      <Icon icon="Lattice" /> {format_num(dataset.n_materials, `.3~s`)} materials
+    </span>
   {/if}
 
-  <div
+  <span
     title="The dataset is {dataset.open ? `freely ` : `in`}accessible"
     {@attach tooltip()}
   >
     <Icon icon={dataset.open ? `Unlock` : `Lock`} />
     {dataset.open ? `Open` : `Closed`}
-  </div>
+  </span>
 
-  <div>
-    <Icon icon="License" />
-    {dataset.license}
-  </div>
+  <span><Icon icon="License" /> {dataset.license}</span>
 </section>
 
 <section class="links">
-  <a
-    href={dataset.url}
-    {...ext_link_props}
-    title="View dataset website"
-    {@attach tooltip()}
-  >
+  <a href={dataset.url} {...link_props} title="View dataset website" {@attach tooltip()}>
     <Icon icon="Globe" /> Website
   </a>
 
   {#if dataset.download_url}
     <a
       href={dataset.download_url}
-      {...ext_link_props}
+      {...link_props}
       title="Download dataset"
       {@attach tooltip()}
     >
@@ -107,7 +87,7 @@
   {#if dataset.doi}
     <a
       href={dataset.doi}
-      {...ext_link_props}
+      {...link_props}
       title="Digital Object Identifier"
       {@attach tooltip()}
     >
@@ -117,7 +97,7 @@
 
   <a
     href="{pkg.repository}/blob/main/data/datasets.yml"
-    {...ext_link_props}
+    {...link_props}
     title="View source YAML file"
     {@attach tooltip()}
   >
@@ -197,16 +177,16 @@
             </a>
           {/if}
           {#if person.github}
-            <a href={person.github} {...ext_link_props} aria-label="GitHub">
+            <a href={person.github} {...link_props} aria-label="GitHub">
               <Icon icon="GitHub" />
             </a>
           {/if}
           {#if person.orcid}
-            <a href={person.orcid} {...ext_link_props} aria-label="ORCID">
+            <a href={person.orcid} {...link_props} aria-label="ORCID">
               <Icon icon="Orcid" />
             </a>{/if}
           {#if person.url}
-            <a href={person.url} {...ext_link_props} aria-label="Website">
+            <a href={person.url} {...link_props} aria-label="Website">
               <Icon icon="Globe" />
             </a>{/if}
         </li>
@@ -221,7 +201,7 @@
 
 <p>
   See incorrect or missing data? Suggest an edit to
-  <a href="{pkg.repository}/blob/-/data/datasets.yml" {...ext_link_props}>
+  <a href="{pkg.repository}/blob/-/data/datasets.yml" {...link_props}>
     datasets.yml
   </a>
 </p>
@@ -255,8 +235,7 @@
     max-width: 12em;
   }
   .links a {
-    gap: 5px;
-    padding: 2pt 6pt;
+    padding: 0 5pt;
     background-color: rgba(255, 255, 255, 0.1);
     border-radius: 5px;
     color: lightgray;

--- a/site/src/routes/models/[slug]/+page.svelte
+++ b/site/src/routes/models/[slug]/+page.svelte
@@ -33,13 +33,13 @@
 
 {#if data.model}
   {@const model = data.model}
-  {@const { missing_preds, missing_percent } = model.metrics?.discovery?.unique_prototypes ??
+  {@const { missing_preds } = model.metrics?.discovery?.unique_prototypes ??
     {}}
   <div class="model-detail">
     <h1 style="font-size: 2.5em">{model.model_name}</h1>
 
     <section class="meta-info">
-      <div>
+      <span>
         <Icon icon="Versions" />
         Version: {#if model.repo?.startsWith(`http`)}
           <a
@@ -52,50 +52,41 @@
         {:else}
           {model.model_version}
         {/if}
-      </div>
+      </span>
 
-      <div>
-        <Icon icon="Calendar" />
-        Added: <span title="{days_added} days ago" {@attach tooltip()}>
-          {model.date_added}
-        </span>
-      </div>
+      <span title="{days_added} days ago" {@attach tooltip()}><Icon icon="Calendar" />
+        Added: {model.date_added}
+      </span>
 
-      <div>
-        <Icon icon="CalendarCheck" />
-        Published: <span title="{days_published} days ago" {@attach tooltip()}>
-          {model.date_published}
-        </span>
-      </div>
+      <span title="{days_published} days ago" {@attach tooltip()}>
+        <Icon icon="CalendarCheck" /> Published: {model.date_published}
+      </span>
 
-      <div>
-        <Icon icon="NeuralNetwork" />
-        <span title={model.model_params.toLocaleString()} {@attach tooltip()}>
-          {format_num(model.model_params, `.3~s`)}
-        </span> parameters
-      </div>
+      <span title={model.model_params.toLocaleString()} {@attach tooltip()}>
+        <Icon icon="NeuralNetwork" /> {format_num(model.model_params, `.3~s`)}
+        parameters
+      </span>
 
       {#if model.n_estimators > 1}
-        <div>
-          <Icon icon="Forest" />
-          <span>Ensemble {model.n_estimators} models</span>
-        </div>
+        <span><Icon icon="Forest" /> Ensemble {model.n_estimators} models</span>
       {/if}
 
       {#if missing_preds != undefined}
-        <div>
+        <span
+          {@attach tooltip()}
+          title="Out of {format_num(DATASETS.WBM.n_structures, `,`)} WBM structures, {format_num(missing_preds, `,`)} are missing predictions. This refers only to the discovery task of predicting WBM convex hull distances."
+        >
           <Icon icon="MissingMetadata" />
-          <span>
-            Missing preds: {format_num(missing_preds, `,.0f`)}
-            {#if missing_preds != 0}
-              <small> ({missing_percent})</small>
-            {/if}
-          </span>
-        </div>
+          Missing preds: {format_num(missing_preds, `,.0f`)}
+          {#if missing_preds != 0}
+            <small>
+              ({format_num(missing_preds / DATASETS.WBM.n_structures, `.3~%`)})</small>
+          {/if}
+        </span>
       {/if}
 
       {#if model.pypi}
-        <code style="background-color: transparent">
+        <code style="padding: 0 4pt">
           pip install {model.pypi.split(`/`).pop()}
           <CopyButton
             content={`pip install ${model.pypi.split(`/`).pop()}`}
@@ -110,7 +101,7 @@
     </section>
 
     <section class="links" {@attach tooltip()}>
-      {#if model.repo.startsWith(`http`)}
+      {#if model.repo?.startsWith(`http`)}
         <a
           href={model.repo}
           target="_blank"
@@ -424,7 +415,7 @@
         <h2>Dependencies</h2>
         <ul>
           {#each Object.entries(model.requirements) as [pkg, version] (pkg)}
-            {@const href = version.startsWith(`http`)
+            {@const href = version?.startsWith(`http`)
           ? version
           : `https://pypi.org/project/${pkg}/${version}`}
             <li>
@@ -470,22 +461,20 @@
     display: block;
     font-weight: bold;
   }
-  .meta-info,
-  .links {
+  .meta-info, .links {
     display: flex;
     flex-wrap: wrap;
-    gap: 3ex;
+    gap: 2ex;
     place-content: center;
     margin: 2em auto;
   }
   .links :is(a, summary) {
     display: inline-flex;
-    align-items: center;
+    place-items: center;
     gap: 5px;
-    padding: 5px 10px;
+    padding: 0 5pt;
     background-color: rgba(255, 255, 255, 0.1);
     border-radius: 5px;
-    text-decoration: none;
     color: lightgray;
   }
   .links details {

--- a/site/tests/index.ts
+++ b/site/tests/index.ts
@@ -31,6 +31,14 @@ export function doc_query<T extends HTMLElement>(
   return node as T
 }
 
+// Helper function to check if an element is hidden
+export function is_hidden(el: Element | null): boolean {
+  if (!el) return true
+  const style = getComputedStyle(el as HTMLElement)
+  return (style.display === `none` || style.visibility === `hidden` ||
+    el.getAttribute(`aria-hidden`) === `true` || el.hasAttribute(`hidden`))
+}
+
 // mock matchMedia browser API
 globalThis.matchMedia = vi.fn()
 

--- a/site/tests/lib/DynamicScatter.test.svelte.ts
+++ b/site/tests/lib/DynamicScatter.test.svelte.ts
@@ -2,7 +2,7 @@ import DynamicScatter from '$lib/DynamicScatter.svelte'
 import type { ModelData } from '$lib/types'
 import { mount } from 'svelte'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { doc_query } from '../index'
+import { doc_query, is_hidden } from '../index'
 
 const pane_selector = `[aria-label="Draggable pane"]`
 
@@ -162,12 +162,7 @@ describe(`DynamicScatter.svelte`, () => {
       let extra_controls = document.body.querySelector(pane_selector)
 
       // 1. Initial state: Controls hidden (element may exist but be hidden)
-      const is_hidden = !extra_controls ||
-        getComputedStyle(extra_controls as HTMLElement).display === `none` ||
-        getComputedStyle(extra_controls as HTMLElement).visibility === `hidden` ||
-        (extra_controls as HTMLElement).getAttribute(`aria-hidden`) === `true` ||
-        (extra_controls as HTMLElement).hasAttribute(`hidden`)
-      expect(is_hidden).toBe(true)
+      expect(is_hidden(extra_controls)).toBe(true)
 
       // 2. Show controls via button click
       await settings_button?.click()
@@ -180,12 +175,8 @@ describe(`DynamicScatter.svelte`, () => {
       )
       await vi.waitFor(() => {
         extra_controls = doc_query<HTMLElement>(pane_selector)
-        // The panel should be hidden but still in DOM
-        const hidden = getComputedStyle(extra_controls).display === `none` ||
-          getComputedStyle(extra_controls).visibility === `hidden` ||
-          extra_controls.getAttribute(`aria-hidden`) === `true` ||
-          extra_controls.hasAttribute(`hidden`)
-        expect(hidden).toBe(true)
+        // The pane should be hidden but still in DOM
+        expect(is_hidden(extra_controls)).toBe(true)
       })
 
       // 4. Re-show controls via button click
@@ -219,12 +210,8 @@ describe(`DynamicScatter.svelte`, () => {
       await outside_element.click() // Simulate click outside
       await vi.waitFor(() => {
         extra_controls = doc_query<HTMLElement>(pane_selector)
-        // The panel should be hidden but still in DOM
-        const hidden = getComputedStyle(extra_controls).display === `none` ||
-          getComputedStyle(extra_controls).visibility === `hidden` ||
-          extra_controls.getAttribute(`aria-hidden`) === `true` ||
-          extra_controls.hasAttribute(`hidden`)
-        expect(hidden).toBe(true)
+        // The pane should be hidden but still in DOM
+        expect(is_hidden(extra_controls)).toBe(true)
       })
 
       // Clean up the outside element

--- a/site/tests/lib/DynamicScatter.test.svelte.ts
+++ b/site/tests/lib/DynamicScatter.test.svelte.ts
@@ -159,17 +159,19 @@ describe(`DynamicScatter.svelte`, () => {
       const settings_button = document.body.querySelector<HTMLButtonElement>(
         `.settings-toggle`,
       )
-      let extra_controls = document.body.querySelector(`.controls`)
+      let extra_controls = document.body.querySelector(pane_selector)
 
       // 1. Initial state: Controls hidden (element may exist but be hidden)
-      if (extra_controls) {
-        const css_display = (extra_controls as HTMLElement).style.display
-        expect([`none`, ``].includes(css_display)).toBe(true)
-      } else expect(extra_controls).toBeNull()
+      const is_hidden = !extra_controls ||
+        getComputedStyle(extra_controls as HTMLElement).display === `none` ||
+        getComputedStyle(extra_controls as HTMLElement).visibility === `hidden` ||
+        (extra_controls as HTMLElement).getAttribute(`aria-hidden`) === `true` ||
+        (extra_controls as HTMLElement).hasAttribute(`hidden`)
+      expect(is_hidden).toBe(true)
 
       // 2. Show controls via button click
       await settings_button?.click()
-      extra_controls = document.body.querySelector(pane_selector)
+      extra_controls = doc_query<HTMLElement>(pane_selector)
       expect(extra_controls).toBeDefined()
 
       // 3. Hide controls via Escape key
@@ -177,15 +179,18 @@ describe(`DynamicScatter.svelte`, () => {
         new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }),
       )
       await vi.waitFor(() => {
-        extra_controls = document.body.querySelector(pane_selector)
+        extra_controls = doc_query<HTMLElement>(pane_selector)
         // The panel should be hidden but still in DOM
-        const css_display = (extra_controls as HTMLElement)?.style.display
-        expect([`none`, ``].includes(css_display)).toBe(true)
+        const hidden = getComputedStyle(extra_controls).display === `none` ||
+          getComputedStyle(extra_controls).visibility === `hidden` ||
+          extra_controls.getAttribute(`aria-hidden`) === `true` ||
+          extra_controls.hasAttribute(`hidden`)
+        expect(hidden).toBe(true)
       })
 
       // 4. Re-show controls via button click
       await settings_button?.click()
-      extra_controls = document.body.querySelector(pane_selector)
+      extra_controls = doc_query<HTMLElement>(pane_selector)
       expect(extra_controls).toBeDefined()
     })
 
@@ -203,20 +208,23 @@ describe(`DynamicScatter.svelte`, () => {
       const settings_button = document.body.querySelector<HTMLButtonElement>(
         `.settings-toggle`,
       )
-      let extra_controls = document.body.querySelector(pane_selector)
+      let extra_controls = doc_query<HTMLElement>(pane_selector)
 
       // 1. Show controls
       await settings_button?.click()
-      extra_controls = document.body.querySelector(pane_selector)
+      extra_controls = doc_query<HTMLElement>(pane_selector)
       expect(extra_controls).toBeDefined()
 
       // 2. Click the explicit outside element
       await outside_element.click() // Simulate click outside
       await vi.waitFor(() => {
-        extra_controls = document.body.querySelector(pane_selector)
+        extra_controls = doc_query<HTMLElement>(pane_selector)
         // The panel should be hidden but still in DOM
-        const css_display = (extra_controls as HTMLElement)?.style.display
-        expect([`none`, ``].includes(css_display)).toBe(true)
+        const hidden = getComputedStyle(extra_controls).display === `none` ||
+          getComputedStyle(extra_controls).visibility === `hidden` ||
+          extra_controls.getAttribute(`aria-hidden`) === `true` ||
+          extra_controls.hasAttribute(`hidden`)
+        expect(hidden).toBe(true)
       })
 
       // Clean up the outside element
@@ -235,7 +243,6 @@ describe(`DynamicScatter.svelte`, () => {
       await settings_button?.click() // Show controls
 
       const extra_controls = doc_query(pane_selector)
-      expect(extra_controls, `Extra controls panel should exist`).toBeDefined()
 
       // --- Find Controls ---
       const color_scale_select_el = extra_controls?.querySelector(`.color-scale-select`)

--- a/site/tests/lib/DynamicScatter.test.svelte.ts
+++ b/site/tests/lib/DynamicScatter.test.svelte.ts
@@ -163,13 +163,11 @@ describe(`DynamicScatter.svelte`, () => {
       if (extra_controls) {
         const css_display = (extra_controls as HTMLElement).style.display
         expect([`none`, ``].includes(css_display)).toBe(true)
-      } else {
-        expect(extra_controls).toBeNull()
-      }
+      } else expect(extra_controls).toBeNull()
 
       // 2. Show controls via button click
       await settings_button?.click()
-      extra_controls = document.body.querySelector(`[aria-label="Draggable panel"]`)
+      extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
       expect(extra_controls).toBeDefined()
 
       // 3. Hide controls via Escape key
@@ -177,7 +175,7 @@ describe(`DynamicScatter.svelte`, () => {
         new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }),
       )
       await vi.waitFor(() => {
-        extra_controls = document.body.querySelector(`[aria-label="Draggable panel"]`)
+        extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
         // The panel should be hidden but still in DOM
         const css_display = (extra_controls as HTMLElement)?.style.display
         expect([`none`, ``].includes(css_display)).toBe(true)
@@ -185,7 +183,7 @@ describe(`DynamicScatter.svelte`, () => {
 
       // 4. Re-show controls via button click
       await settings_button?.click()
-      extra_controls = document.body.querySelector(`[aria-label="Draggable panel"]`)
+      extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
       expect(extra_controls).toBeDefined()
     })
 
@@ -203,17 +201,17 @@ describe(`DynamicScatter.svelte`, () => {
       const settings_button = document.body.querySelector<HTMLButtonElement>(
         `.settings-toggle`,
       )
-      let extra_controls = document.body.querySelector(`[aria-label="Draggable panel"]`)
+      let extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
 
       // 1. Show controls
       await settings_button?.click()
-      extra_controls = document.body.querySelector(`[aria-label="Draggable panel"]`)
+      extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
       expect(extra_controls).toBeDefined()
 
       // 2. Click the explicit outside element
       await outside_element.click() // Simulate click outside
       await vi.waitFor(() => {
-        extra_controls = document.body.querySelector(`[aria-label="Draggable panel"]`)
+        extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
         // The panel should be hidden but still in DOM
         const css_display = (extra_controls as HTMLElement)?.style.display
         expect([`none`, ``].includes(css_display)).toBe(true)
@@ -234,7 +232,7 @@ describe(`DynamicScatter.svelte`, () => {
       )
       await settings_button?.click() // Show controls
 
-      const extra_controls = doc_query(`[aria-label="Draggable panel"]`)
+      const extra_controls = doc_query(`[aria-label="Draggable pane"]`)
       expect(extra_controls, `Extra controls panel should exist`).toBeDefined()
 
       // --- Find Controls ---

--- a/site/tests/lib/DynamicScatter.test.svelte.ts
+++ b/site/tests/lib/DynamicScatter.test.svelte.ts
@@ -4,6 +4,8 @@ import { mount } from 'svelte'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { doc_query } from '../index'
 
+const pane_selector = `[aria-label="Draggable pane"]`
+
 const mock_models: ModelData[] = [
   {
     model_name: `Test Model 1`,
@@ -167,7 +169,7 @@ describe(`DynamicScatter.svelte`, () => {
 
       // 2. Show controls via button click
       await settings_button?.click()
-      extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
+      extra_controls = document.body.querySelector(pane_selector)
       expect(extra_controls).toBeDefined()
 
       // 3. Hide controls via Escape key
@@ -175,7 +177,7 @@ describe(`DynamicScatter.svelte`, () => {
         new KeyboardEvent(`keydown`, { key: `Escape`, bubbles: true }),
       )
       await vi.waitFor(() => {
-        extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
+        extra_controls = document.body.querySelector(pane_selector)
         // The panel should be hidden but still in DOM
         const css_display = (extra_controls as HTMLElement)?.style.display
         expect([`none`, ``].includes(css_display)).toBe(true)
@@ -183,7 +185,7 @@ describe(`DynamicScatter.svelte`, () => {
 
       // 4. Re-show controls via button click
       await settings_button?.click()
-      extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
+      extra_controls = document.body.querySelector(pane_selector)
       expect(extra_controls).toBeDefined()
     })
 
@@ -201,17 +203,17 @@ describe(`DynamicScatter.svelte`, () => {
       const settings_button = document.body.querySelector<HTMLButtonElement>(
         `.settings-toggle`,
       )
-      let extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
+      let extra_controls = document.body.querySelector(pane_selector)
 
       // 1. Show controls
       await settings_button?.click()
-      extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
+      extra_controls = document.body.querySelector(pane_selector)
       expect(extra_controls).toBeDefined()
 
       // 2. Click the explicit outside element
       await outside_element.click() // Simulate click outside
       await vi.waitFor(() => {
-        extra_controls = document.body.querySelector(`[aria-label="Draggable pane"]`)
+        extra_controls = document.body.querySelector(pane_selector)
         // The panel should be hidden but still in DOM
         const css_display = (extra_controls as HTMLElement)?.style.display
         expect([`none`, ``].includes(css_display)).toBe(true)
@@ -232,7 +234,7 @@ describe(`DynamicScatter.svelte`, () => {
       )
       await settings_button?.click() // Show controls
 
-      const extra_controls = doc_query(`[aria-label="Draggable pane"]`)
+      const extra_controls = doc_query(pane_selector)
       expect(extra_controls, `Extra controls panel should exist`).toBeDefined()
 
       // --- Find Controls ---

--- a/site/tests/lib/metrics.test.ts
+++ b/site/tests/lib/metrics.test.ts
@@ -781,7 +781,7 @@ describe(`Model Sorting Logic`, () => {
         model_key: `mmm_model`,
         metrics: {
           discovery: {
-            unique_prototypes: { F1: 0.7, Accuracy: NaN, missing_preds: 0 }, // Test NaN handling
+            unique_prototypes: { F1: 0.7, Accuracy: NaN, missing_preds: 2 }, // NaN Accuracy + non-zero missing_preds
             pred_col: `is_stable`,
           },
           phonons: { kappa_103: { κ_SRME: 0.5 } },
@@ -792,7 +792,7 @@ describe(`Model Sorting Logic`, () => {
         model_key: `zzz_model`,
         metrics: {
           discovery: {
-            unique_prototypes: { F1: 0.5, Accuracy: 0.6, missing_preds: 0 },
+            unique_prototypes: { F1: 0.5, Accuracy: 0.6, missing_preds: 5 },
             pred_col: `is_stable`,
           },
           phonons: { kappa_103: { κ_SRME: 0.2 } },
@@ -891,6 +891,17 @@ describe(`Model Sorting Logic`, () => {
         expect(sorted_models[idx].model_key, metric).toBe(model_key)
       })
     }
+
+    // Add descending-Accuracy test to assert NaN handling is symmetric
+    const sorted_desc = test_models.sort(
+      sort_models(`${Accuracy.path}.${Accuracy.key}`, `desc`),
+    )
+    expect(sorted_desc.map((m) => m.model_key)).toEqual([
+      `aaa_model`,
+      `zzz_model`,
+      `mmm_model`,
+      `missing_model`,
+    ])
   })
 
   it(`sorts models by model_name correctly`, () => {
@@ -920,6 +931,19 @@ describe(`Model Sorting Logic`, () => {
     expect(models_for_desc.map((m) => m.model_key).sort()).toEqual(
       expected_model_keys.sort(),
     )
+  })
+
+  it(`sorts models by missing predictions (asc)`, () => {
+    const models = create_test_models()
+    const sorted = models.sort(
+      sort_models(`metrics.discovery.unique_prototypes.missing_preds`, `asc`),
+    )
+    expect(sorted.map((m) => m.model_key)).toEqual([
+      `aaa_model`,
+      `mmm_model`,
+      `zzz_model`,
+      `missing_model`,
+    ])
   })
 
   it(`handles edge cases with missing or extreme metric values`, () => {

--- a/site/tests/lib/metrics.test.ts
+++ b/site/tests/lib/metrics.test.ts
@@ -737,7 +737,6 @@ describe(`METADATA_COLS`, () => {
       `Checkpoint License`,
       `Code License`,
       `Missing Predictions`,
-      `Missing %`,
       `Run Time`,
       `Org`,
     ]
@@ -771,7 +770,7 @@ describe(`Model Sorting Logic`, () => {
         model_key: `aaa_model`,
         metrics: {
           discovery: {
-            unique_prototypes: { F1: 0.9, Accuracy: 0.85 },
+            unique_prototypes: { F1: 0.9, Accuracy: 0.85, missing_preds: 0 },
             pred_col: `is_stable`,
           },
           phonons: { kappa_103: { κ_SRME: 0.9 } },
@@ -782,7 +781,7 @@ describe(`Model Sorting Logic`, () => {
         model_key: `mmm_model`,
         metrics: {
           discovery: {
-            unique_prototypes: { F1: 0.7, Accuracy: NaN }, // Test NaN handling
+            unique_prototypes: { F1: 0.7, Accuracy: NaN, missing_preds: 0 }, // Test NaN handling
             pred_col: `is_stable`,
           },
           phonons: { kappa_103: { κ_SRME: 0.5 } },
@@ -793,7 +792,7 @@ describe(`Model Sorting Logic`, () => {
         model_key: `zzz_model`,
         metrics: {
           discovery: {
-            unique_prototypes: { F1: 0.5, Accuracy: 0.6 },
+            unique_prototypes: { F1: 0.5, Accuracy: 0.6, missing_preds: 0 },
             pred_col: `is_stable`,
           },
           phonons: { kappa_103: { κ_SRME: 0.2 } },

--- a/tests/dataset-schema.yml
+++ b/tests/dataset-schema.yml
@@ -94,6 +94,14 @@ definitions:
         type: integer
         minimum: 1
         description: Number of unique materials in the dataset
+      n_stable_materials:
+        type: integer
+        minimum: 1
+        description: Number of stable materials in the dataset
+      n_uniq_stable_materials:
+        type: integer
+        minimum: 1
+        description: Number of unique stable materials in the dataset
       elements:
         type: array
         items:

--- a/tests/label-schema.yml
+++ b/tests/label-schema.yml
@@ -75,7 +75,6 @@ definitions:
       checkpoint_license: { $ref: '#/definitions/Label' }
       code_license: { $ref: '#/definitions/Label' }
       missing_preds: { $ref: '#/definitions/Label' }
-      missing_percent: { $ref: '#/definitions/Label' }
       'Run Time (h)': { $ref: '#/definitions/Label' }
       org: { $ref: '#/definitions/Label' }
     required:
@@ -90,7 +89,6 @@ definitions:
       - checkpoint_license
       - code_license
       - missing_preds
-      - missing_percent
       - 'Run Time (h)'
       - org
     additionalProperties: false

--- a/tests/metrics/diatomics/test_diatomics_energy.py
+++ b/tests/metrics/diatomics/test_diatomics_energy.py
@@ -340,7 +340,7 @@ def smoothness_test_data() -> dict[str, EnergyCurve]:
 def test_smoothness_exact_values(
     metric_func: Callable[[np.ndarray, np.ndarray], float],
     curve_name: str,
-    expected_val: float,
+    expected_val: object,
     smoothness_test_data: dict[str, tuple[np.ndarray, np.ndarray]],
 ) -> None:
     """Test exact values of smoothness metrics for well-understood curves.

--- a/tests/metrics/diatomics/test_diatomics_energy.py
+++ b/tests/metrics/diatomics/test_diatomics_energy.py
@@ -326,7 +326,7 @@ def smoothness_test_data() -> dict[str, EnergyCurve]:
 
 
 @pytest.mark.parametrize(
-    "metric_func,curve_name,expected_value",
+    "metric_func,curve_name,expected_val",
     [
         # Second derivative should be very close to 0 for constant and linear curves
         (calc_second_deriv_smoothness, "constant", pytest.approx(0, abs=1e-10)),
@@ -340,7 +340,7 @@ def smoothness_test_data() -> dict[str, EnergyCurve]:
 def test_smoothness_exact_values(
     metric_func: Callable[[np.ndarray, np.ndarray], float],
     curve_name: str,
-    expected_value: float,
+    expected_val: float,
     smoothness_test_data: dict[str, tuple[np.ndarray, np.ndarray]],
 ) -> None:
     """Test exact values of smoothness metrics for well-understood curves.
@@ -348,12 +348,12 @@ def test_smoothness_exact_values(
     Args:
         metric_func (Callable): Smoothness metric function to test
         curve_name (str): Name of curve to test
-        expected_value (float): Expected metric value
+        expected_val (float): Expected metric value
         smoothness_test_data (dict): Test curves
     """
     x, y = smoothness_test_data[curve_name]
     metric = metric_func(x, y)
-    assert metric == expected_value
+    assert metric == expected_val
 
 
 @pytest.mark.parametrize(

--- a/tests/metrics/test_geo_opt_metrics.py
+++ b/tests/metrics/test_geo_opt_metrics.py
@@ -188,11 +188,11 @@ def test_write_geo_opt_metrics_to_yaml(
 
             # Compare metrics while handling NaN values
             for key, value in actual_yaml["metrics"]["geo_opt"][symprec_key].items():
-                expected_value = expected_yaml["metrics"]["geo_opt"][symprec_key][key]
+                expected_val = expected_yaml["metrics"]["geo_opt"][symprec_key][key]
                 if isinstance(value, float) and np.isnan(value):
-                    assert np.isnan(expected_value)
+                    assert np.isnan(expected_val)
                 else:
-                    assert value == pytest.approx(expected_value)
+                    assert value == pytest.approx(expected_val)
 
             # Verify file operations
             mock_file.assert_called()

--- a/tests/metrics/test_metrics_init.py
+++ b/tests/metrics/test_metrics_init.py
@@ -1,7 +1,5 @@
 """Test metrics/__init__.py module."""
 
-import sys
-
 from matbench_discovery.enums import TestSubset
 from matbench_discovery.metrics import metrics_df_from_yaml
 
@@ -19,9 +17,10 @@ def test_metrics_df_from_yaml_discovery() -> None:
 def test_metrics_df_from_yaml_phonons() -> None:
     """Test extracting phonon metrics."""
     df_metrics = metrics_df_from_yaml(["phonons.kappa_103"])
-    # need different char encoding on Windows and linux
-    kappa_col = "\xce\xba_SRME" if sys.platform == "win32" else "\u03ba_SRME"
-    assert kappa_col in df_metrics
+    # Find the kappa column regardless of exact string representation
+    kappa_cols = [col for col in df_metrics if "_SRME" in col]
+    assert len(kappa_cols) == 1, f"No SRME column found in {df_metrics.columns=}"
+    kappa_col = kappa_cols[0]
     assert df_metrics.shape >= (16, 3)
     assert all(df_metrics[kappa_col] >= 0), f"{df_metrics[kappa_col]=}"
 

--- a/tests/metrics/test_metrics_init.py
+++ b/tests/metrics/test_metrics_init.py
@@ -18,8 +18,8 @@ def test_metrics_df_from_yaml_phonons() -> None:
     """Test extracting phonon metrics."""
     df_metrics = metrics_df_from_yaml(["phonons.kappa_103"])
     # Find the kappa column regardless of exact string representation
-    kappa_cols = [col for col in df_metrics if "_SRME" in col]
-    assert len(kappa_cols) == 1, f"No SRME column found in {df_metrics.columns=}"
+    kappa_cols = [col for col in df_metrics if col.endswith("_SRME")]
+    assert len(kappa_cols) == 1, f"{df_metrics.columns=}"
     kappa_col = kappa_cols[0]
     assert df_metrics.shape >= (16, 3)
     assert all(df_metrics[kappa_col] >= 0), f"{df_metrics[kappa_col]=}"

--- a/tests/metrics/test_phonon_metrics.py
+++ b/tests/metrics/test_phonon_metrics.py
@@ -515,9 +515,14 @@ def test_write_metrics_to_yaml(
             actual_kappa_103 = actual_yaml["metrics"]["phonons"]["kappa_103"]
 
             # Check new metrics were added
-            for key, expected_value in expected_metrics.items():
-                assert actual_kappa_103[key] == pytest.approx(expected_value, rel=1e-4)
+            for key, expected_val in expected_metrics.items():
+                if isinstance(expected_val, float):
+                    assert actual_kappa_103[key] == pytest.approx(
+                        expected_val, rel=1e-4
+                    )
+                else:
+                    assert actual_kappa_103[key] == expected_val
 
             # Check existing fields were preserved
-            for key, expected_value in expected_preserved.items():
-                assert actual_kappa_103[key] == expected_value
+            for key, expected_val in expected_preserved.items():
+                assert actual_kappa_103[key] == expected_val

--- a/tests/metrics/test_phonon_metrics.py
+++ b/tests/metrics/test_phonon_metrics.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 from numpy.typing import NDArray
 from pymatviz.enums import Key
 
-from matbench_discovery.enums import MbdKey
+from matbench_discovery.enums import MbdKey, Model
 from matbench_discovery.metrics import phonons as phonon_metrics
 
 
@@ -397,12 +397,12 @@ def test_calc_kappa_srme_temperature_dependence(series_multi_temp: pd.Series) ->
 
 def test_calc_kappa_metrics_from_dfs_symmetry(df_minimal: pd.DataFrame) -> None:
     """Test handling of symmetry-related cases in benchmark descriptors."""
-    df_pred = pd.concat([df_minimal] * 3, ignore_index=True)
+    df_pred = pd.concat([df_minimal] * 3, ignore_index=True).copy()
     df_pred[Key.has_imag_ph_modes] = [False, True, False]
     df_pred[Key.final_spg_num] = [1, 1, 2]
     df_pred[Key.init_spg_num] = [1, 1, 1]
 
-    df_true = pd.concat([df_minimal] * 3, ignore_index=True)
+    df_true = pd.concat([df_minimal] * 3, ignore_index=True).copy()
     df_true[Key.spg_num] = [1, 1, 1]
 
     result = phonon_metrics.calc_kappa_metrics_from_dfs(df_pred, df_true)
@@ -413,16 +413,111 @@ def test_calc_kappa_metrics_from_dfs_symmetry(df_minimal: pd.DataFrame) -> None:
 
 def test_calc_kappa_srme_dataframes_error_handling(df_minimal: pd.DataFrame) -> None:
     """Test error handling in SRME calculation for dataframes."""
-    df_pred = pd.concat([df_minimal] * 2, ignore_index=True)
+    df_pred = pd.concat([df_minimal] * 2, ignore_index=True).copy()
     df_pred.loc[0, MbdKey.kappa_tot_avg] = np.nan
     df_pred[Key.has_imag_ph_modes] = [True, False]
     df_pred[Key.final_spg_num] = [2, 1]
     df_pred[Key.init_spg_num] = [1, 1]
 
-    df_true = pd.concat([df_minimal] * 2, ignore_index=True)
+    df_true = pd.concat([df_minimal] * 2, ignore_index=True).copy()
     df_true[Key.spg_num] = [1, 1]
 
     result = phonon_metrics.calc_kappa_srme_dataframes(df_pred, df_true)
     assert len(result) == 2
     assert result[0] == 2  # First entry should be 2 due to imaginary frequencies
     assert 0 <= result[1] <= 2  # Second entry should be valid SRME value
+
+
+@pytest.mark.parametrize(
+    ("metrics_data", "existing_data", "expected_metrics", "expected_preserved"),
+    [
+        # Test case 1: Empty YAML - creates structure and adds metrics
+        (
+            {"srme": 0.6823, "sre": 0.4710},
+            {},
+            {
+                "κ_SRME": 0.6823,
+                "κ_SRE": 0.4710,
+                "pred_file": "models/test/kappa-103.json.gz",
+            },
+            {},
+        ),
+        # Test case 2: Existing fields - preserves them and adds new metrics
+        (
+            {"srme": 0.1234, "sre": 0.5678},
+            {
+                "metrics": {
+                    "phonons": {
+                        "kappa_103": {
+                            "pred_file": "models/test/existing.json.gz",
+                            "pred_file_url": "https://figshare.com/files/existing",
+                            "analysis_file": "models/test/analysis.csv.gz",
+                        }
+                    }
+                }
+            },
+            {"κ_SRME": 0.1234, "κ_SRE": 0.5678},
+            {
+                "pred_file": "models/test/existing.json.gz",
+                "pred_file_url": "https://figshare.com/files/existing",
+                "analysis_file": "models/test/analysis.csv.gz",
+            },
+        ),
+        # Test case 3: Mixed existing data - preserves some, adds new
+        (
+            {"srme": 1.2345, "sre": 0.9876},
+            {
+                "metrics": {
+                    "phonons": {
+                        "kappa_103": {
+                            "existing_field": "preserved_value",
+                            "pred_file_url": "https://figshare.com/files/12345",
+                        }
+                    }
+                }
+            },
+            {
+                "κ_SRME": 1.2345,
+                "κ_SRE": 0.9876,
+                "pred_file": "models/test/kappa-103.json.gz",
+            },
+            {
+                "existing_field": "preserved_value",
+                "pred_file_url": "https://figshare.com/files/12345",
+            },
+        ),
+    ],
+)
+def test_write_metrics_to_yaml(
+    metrics_data: dict[str, float],
+    existing_data: dict[str, dict[str, dict[str, dict[str, str | float]]]],
+    expected_metrics: dict[str, float | str],
+    expected_preserved: dict[str, str | float],
+) -> None:
+    """Test writing kappa metrics to YAML files with various scenarios."""
+    from unittest.mock import MagicMock, mock_open, patch
+
+    mock_model = MagicMock(spec=Model)
+    mock_model.yaml_path = "mock_path/test_model.yml"
+
+    with patch("ruamel.yaml.YAML") as mock_yaml_class:
+        mock_yaml = mock_yaml_class.return_value
+        mock_yaml.load.return_value = existing_data
+
+        with patch("builtins.open", mock_open()):
+            phonon_metrics.write_metrics_to_yaml(
+                mock_model,  # type: ignore[arg-type]
+                metrics_data,
+                "models/test/kappa-103.json.gz",
+            )
+
+            actual_yaml = mock_yaml.dump.call_args[0][0]
+            actual_kappa_103 = actual_yaml["metrics"]["phonons"]["kappa_103"]
+
+            # Check new metrics were added
+            for key, expected_value in expected_metrics.items():
+                assert actual_kappa_103[key] == pytest.approx(expected_value, rel=1e-4)
+
+            # Check existing fields were preserved
+            for key, expected_value in expected_preserved.items():
+                assert actual_kappa_103[key] == expected_value

--- a/tests/model-schema.yml
+++ b/tests/model-schema.yml
@@ -173,8 +173,24 @@ definitions:
         type: number
       missing_preds:
         type: number
-      missing_percent:
-        type: string
+    required:
+      - F1
+      - DAF
+      - Precision
+      - Recall
+      - Accuracy
+      - TPR
+      - FPR
+      - TNR
+      - FNR
+      - TP
+      - FP
+      - TN
+      - FN
+      - MAE
+      - RMSE
+      - R2
+      - missing_preds
 
   DiscoveryMetrics:
     type: object


### PR DESCRIPTION
- Add WBM to the dataset catalog with complete metadata, material counts, schema updates, and a README link.
- Add a phonon-kappa metrics writer that persists results into model metadata.
- Remove the static Missing % column and compute the percentage in the UI with an explanatory tooltip.
- Streamline dataset/model metadata layouts, harden external links, and improve CLI error handling.