### PR TITLE
Clean Stale PRs Automatically Unless Labelled

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: 'Close Stale Pull Requests'
+
+on:
+  schedule:
+    # Run every day at midnight UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  stale-pull-requests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-pr-stale: 90 # Days of inactivity before marking as stale
+          days-before-pr-close: 30 # Days of inactivity after 'stale' label before closing
+          stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 30 days. Please update it or it will be automatically closed in 60 days.'
+          close-pr-message: 'This pull request has been automatically closed due to prolonged inactivity. Please reopen if you still intend to submit this PR.'
+          stale-pr-label: 'stale' # Label to apply when marking as stale
+          exempt-pr-labels: 'keep-open' # Labels that exempt a PR from being marked stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: -1 # Disable issue staleness, only manage PRs
           days-before-pr-stale: 90 # Days of inactivity before marking as stale
           days-before-pr-close: 30 # Days of inactivity after 'stale' label before closing
           stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 90 days. Please update it or it will be automatically closed in 30 days.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-pr-stale: 90 # Days of inactivity before marking as stale
           days-before-pr-close: 30 # Days of inactivity after 'stale' label before closing
-          stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 30 days. Please update it or it will be automatically closed in 60 days.'
+          stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 90 days. Please update it or it will be automatically closed in 30 days.'
           close-pr-message: 'This pull request has been automatically closed due to prolonged inactivity. Please reopen if you still intend to submit this PR.'
           stale-pr-label: 'stale' # Label to apply when marking as stale
           exempt-pr-labels: 'keep-open' # Labels that exempt a PR from being marked stale


### PR DESCRIPTION
Adds a daily workflow that marks pull requests stale after 90 days of inactivity and closes them after another 30 days.

The workflow supports configurable exemptions, labels, and notification messages so intentionally inactive pull requests can remain open.