### PR TITLE
Update EquiformerV3 submission

### DIFF
--- a/models/equiformer_v3/equiformer_v3_mp.yml
+++ b/models/equiformer_v3/equiformer_v3_mp.yml
@@ -1,4 +1,4 @@
-model_name: EquiformerV3-MP
+model_name: EquiformerV3+DeNS-MP
 model_key: equiformer_v3_mp
 model_version: v2026.04.07
 date_added: '2026-04-07'
@@ -32,8 +32,8 @@ trained_by:
 
 
 repo: https://github.com/atomicarchitects/equiformer_v3
-doi: https://github.com/atomicarchitects/equiformer_v3
-paper: https://github.com/atomicarchitects/equiformer_v3
+doi: https://doi.org/10.48550/arXiv.2604.09130
+paper: https://arxiv.org/abs/2604.09130
 url: https://github.com/atomicarchitects/equiformer_v3
 pr_url: https://github.com/janosh/matbench-discovery/pull/320
 checkpoint_url: https://github.com/atomicarchitects/equiformer_v3

--- a/models/equiformer_v3/equiformer_v3_oam.yml
+++ b/models/equiformer_v3/equiformer_v3_oam.yml
@@ -1,4 +1,4 @@
-model_name: EquiformerV3-OAM
+model_name: EquiformerV3+DeNS-OAM
 model_key: equiformer_v3_oam
 model_version: v2026.04.07
 date_added: '2026-04-07'
@@ -32,8 +32,8 @@ trained_by:
 
 
 repo: https://github.com/atomicarchitects/equiformer_v3
-doi: https://github.com/atomicarchitects/equiformer_v3
-paper: https://github.com/atomicarchitects/equiformer_v3
+doi: https://doi.org/10.48550/arXiv.2604.09130
+paper: https://arxiv.org/abs/2604.09130
 url: https://github.com/atomicarchitects/equiformer_v3
 pr_url: https://github.com/janosh/matbench-discovery/pull/320
 checkpoint_url: https://github.com/atomicarchitects/equiformer_v3


### PR DESCRIPTION
Updates the EquiformerV3 submission:

- Appends `+DeNS` to `model_name` to credit the prior work.
- Adds arXiv and DOI publication links for attribution and discoverability.