### PR TITLE
Update protostructure data columns

### DIFF
--- a/data/wbm/compile_wbm_test_set.py
+++ b/data/wbm/compile_wbm_test_set.py
@@ -633,11 +633,11 @@ df_summary[MbdKey.e_form_raw.replace("uncorrected", "mp2020_corrected")] = (
 # %%
 # from initial structures
 for idx in tqdm(df_wbm.index):
-    if not pd.isna(df_summary.loc[idx].get(MbdKey.init_wyckoff_spglib)):
+    if not pd.isna(df_summary.loc[idx].get(MbdKey.init_protostructure_spglib)):
         continue  # Aflow label already computed
     try:
         struct = Structure.from_dict(df_wbm.loc[idx, Key.init_struct])
-        df_summary.loc[idx, f"{Key.protostructure}_moyo_init"] = (
+        df_summary.loc[idx, MbdKey.init_protostructure_spglib] = (
             prototype.get_protostructure_label(struct)
         )
     except Exception as exc:
@@ -645,20 +645,20 @@ for idx in tqdm(df_wbm.index):
 
 # from relaxed structures
 for idx in tqdm(df_wbm.index):
-    if not pd.isna(df_summary.loc[idx].get(Key.wyckoff)):
+    if not pd.isna(df_summary.loc[idx].get(MbdKey.protostructure_spglib)):
         continue
 
     try:
         cse = df_wbm.loc[idx, Key.computed_structure_entry]
         struct = Structure.from_dict(cse["structure"])
-        df_summary.loc[idx, f"{Key.protostructure}_moyo_relaxed"] = (
+        df_summary.loc[idx, MbdKey.protostructure_spglib] = (
             prototype.get_protostructure_label(struct)
         )
     except Exception as exc:
         print(f"{idx=} {exc=}")
 
-assert df_summary[MbdKey.init_wyckoff_spglib].isna().sum() == 0
-assert df_summary[Key.wyckoff].isna().sum() == 0
+assert df_summary[MbdKey.init_protostructure_spglib].isna().sum() == 0
+assert df_summary[MbdKey.protostructure_spglib].isna().sum() == 0
 
 
 # %%
@@ -679,13 +679,13 @@ except KeyError:
 df_mp = pd.read_csv(DataFiles.mp_energies.path, index_col=0)
 
 # mask WBM materials with matching prototype in MP
-mask_proto_in_mp = df_summary[MbdKey.init_wyckoff_spglib].isin(
-    df_mp[MbdKey.wyckoff_spglib]
+mask_proto_in_mp = df_summary[MbdKey.init_protostructure_spglib].isin(
+    df_mp[MbdKey.protostructure_spglib]
 )
 # mask duplicate prototypes in WBM (keeping the lowest energy one)
 mask_dupe_protos = df_summary.sort_values(
-    by=[MbdKey.init_wyckoff_spglib, MbdKey.each_wbm]
-).duplicated(subset=MbdKey.init_wyckoff_spglib, keep="first")
+    by=[MbdKey.init_protostructure_spglib, MbdKey.each_wbm]
+).duplicated(subset=MbdKey.init_protostructure_spglib, keep="first")
 assert sum(mask_proto_in_mp) == 11_175, f"{sum(mask_proto_in_mp)=:_}"
 assert sum(mask_dupe_protos) == 32_784, f"{sum(mask_dupe_protos)=:_}"
 

--- a/data/wbm/eda_wbm.py
+++ b/data/wbm/eda_wbm.py
@@ -305,9 +305,11 @@ fig.show()
 
 # %%
 df_wbm[Key.spg_num] = (
-    df_wbm[MbdKey.init_wyckoff_spglib].str.split("_").str[2].astype(int)
+    df_wbm[MbdKey.init_protostructure_spglib].str.split("_").str[2].astype(int)
 )
-df_mp[Key.spg_num] = df_mp[f"{Key.wyckoff}_spglib"].str.split("_").str[2].astype(int)
+df_mp[Key.spg_num] = (
+    df_mp[MbdKey.protostructure_spglib].str.split("_").str[2].astype(int)
+)
 
 
 # %%
@@ -363,8 +365,10 @@ pmv.save_fig(fig, f"{PDF_FIGS}/{img_name}.pdf", width=450, height=280)
 
 # %% find large structures that changed symmetry during relaxation
 df_sym_change = (
-    df_wbm.query(f"{MbdKey.init_wyckoff_spglib} != {MbdKey.wyckoff_spglib}")
-    .filter(regex="wyckoff|sites")
+    df_wbm.query(
+        f"{MbdKey.init_protostructure_spglib} != {MbdKey.protostructure_spglib}"
+    )
+    .filter(regex="protostructure|sites")
     .nlargest(10, Key.n_sites)
 )
 

--- a/matbench_discovery/data-files.yml
+++ b/matbench_discovery/data-files.yml
@@ -66,10 +66,10 @@ wbm_initial_atoms:
   md5: 2a292211ca6acb30ed8416178d644098
 
 wbm_summary:
-  url: https://figshare.com/files/44225498
+  url: https://figshare.com/files/64706751
   path: wbm/2023-12-13-wbm-summary.csv.gz
   description: Computed material properties only, no structures. Available properties are VASP energy, formation energy, energy above the convex hull, volume, band gap, number of sites per unit cell, and more.
-  md5: fb23d85dab61fab001b92cb0ac4f8f3d
+  md5: 1555268d3aa59d20262cb9d01ce0994b
 
 wbm_dft_geo_opt_symprec_1e_2:
   url: https://figshare.com/files/52066799

--- a/matbench_discovery/enums.py
+++ b/matbench_discovery/enums.py
@@ -66,12 +66,12 @@ class MbdKey(LabelEnum):
         f"Error in E<sub>hull dist</sub> {eV_per_atom}",
     )
 
-    init_wyckoff_spglib = (
-        "wyckoff_spglib_initial_structure",
+    init_protostructure_spglib = (
+        "protostructure_spglib_initial_structure",
         "Protostructure Label for Initial Structure using spglib",
     )
-    wyckoff_spglib = (
-        "wyckoff_spglib",
+    protostructure_spglib = (
+        "protostructure_spglib",
         "Protostructure Label for Relaxed Structure using spglib",
     )
     international_spg_name = "international_spg_name", "International space group name"

--- a/models/allegro/analyze_allegro.py
+++ b/models/allegro/analyze_allegro.py
@@ -34,7 +34,7 @@ df_wbm["e_form_per_atom_allegro_error"] = (
 df_allegro[list(df_wbm)] = df_wbm
 
 df_allegro[Key.spg_num] = (
-    df_wbm[MbdKey.init_wyckoff_spglib].str.split("_").str[2].astype(int)
+    df_wbm[MbdKey.init_protostructure_spglib].str.split("_").str[2].astype(int)
 )
 
 

--- a/models/mace/analyze_mace.py
+++ b/models/mace/analyze_mace.py
@@ -24,7 +24,7 @@ df_mace = pd.read_csv(Model.mace_mp_0.discovery_path).set_index(Key.mat_id)
 df_mace[list(df_wbm)] = df_wbm
 
 df_mace[Key.spg_num] = (
-    df_wbm[MbdKey.init_wyckoff_spglib].str.split("_").str[2].astype(int)
+    df_wbm[MbdKey.init_protostructure_spglib].str.split("_").str[2].astype(int)
 )
 
 

--- a/models/nequip/analyze_nequip.py
+++ b/models/nequip/analyze_nequip.py
@@ -31,7 +31,7 @@ df_wbm["e_form_per_atom_nequip_error"] = (
 df_nequip[list(df_wbm)] = df_wbm
 
 df_nequip[Key.spg_num] = (
-    df_wbm[MbdKey.init_wyckoff_spglib].str.split("_").str[2].astype(int)
+    df_wbm[MbdKey.init_protostructure_spglib].str.split("_").str[2].astype(int)
 )
 
 

--- a/models/wrenformer/analyze_wrenformer.py
+++ b/models/wrenformer/analyze_wrenformer.py
@@ -27,7 +27,7 @@ bad_ids = df_each_pred.query(
 ).index
 
 df_wbm[Key.spg_num] = (
-    df_wbm[MbdKey.init_wyckoff_spglib].str.split("_").str[2].astype(int)
+    df_wbm[MbdKey.init_protostructure_spglib].str.split("_").str[2].astype(int)
 )
 df_bad = df_wbm.loc[bad_ids]
 title = f"{len(df_bad)} {model} preds<br>with {max_each_true=}, {min_each_pred=}"
@@ -50,7 +50,7 @@ fig.show()
 
 # %%
 proto_col = "Isopointal Prototypes"
-df_proto_counts = df_bad[MbdKey.init_wyckoff_spglib].value_counts().to_frame()
+df_proto_counts = df_bad[MbdKey.init_protostructure_spglib].value_counts().to_frame()
 
 
 df_proto_counts["MP occurrences"] = 0

--- a/models/wrenformer/test_wrenformer_discovery.py
+++ b/models/wrenformer/test_wrenformer_discovery.py
@@ -42,12 +42,10 @@ slurm_vars = slurm_submit(
 
 
 # %%
-df_wbm_clean = df_wbm.dropna(subset=MbdKey.init_wyckoff_spglib)
+df_wbm_clean = df_wbm.dropna(subset=MbdKey.init_protostructure_spglib)
 
 if MbdKey.e_form_dft not in df_wbm_clean:
     raise KeyError(f"{MbdKey.e_form_dft!s} not in {df_wbm_clean.columns=}")
-if MbdKey.wyckoff_spglib not in df_wbm_clean:
-    raise KeyError(f"{MbdKey.wyckoff_spglib!s} not in {df_wbm_clean.columns=}")
 
 
 # %%
@@ -76,7 +74,7 @@ run_params = dict(
     ensemble_size=len(runs),
     task_type=task_type,
     target_col=MbdKey.e_form_dft,
-    input_col=Key.wyckoff,
+    input_col=MbdKey.init_protostructure_spglib,
     wandb_run_filters=filters,
     slurm_vars=slurm_vars,
     training_run_ids=[run.id for run in runs],
@@ -98,7 +96,7 @@ data_loader = df_to_in_mem_dataloader(
     df=df_wbm_clean,
     batch_size=1024,
     shuffle=False,  # False is default but best be explicit
-    input_col=Key.wyckoff,
+    input_col=MbdKey.init_protostructure_spglib,
     target_col=MbdKey.e_form_dft,
     id_col=Key.mat_id,
     embedding_type="wyckoff",

--- a/models/wrenformer/train_wrenformer.py
+++ b/models/wrenformer/train_wrenformer.py
@@ -51,8 +51,8 @@ df_data = pd.read_csv(data_path).set_index(Key.mat_id, drop=False)
 
 if target_col not in df_data:
     raise TypeError(f"{target_col!s} not in {df_data.columns=}")
-if MbdKey.wyckoff_spglib not in df_data:
-    raise TypeError(f"{MbdKey.wyckoff_spglib!s} not in {df_data.columns=}")
+if MbdKey.protostructure_spglib not in df_data:
+    raise TypeError(f"{MbdKey.protostructure_spglib!s} not in {df_data.columns=}")
 train_df, test_df = df_train_test_split(df_data, test_size=0.05)
 
 run_params = dict(
@@ -74,7 +74,7 @@ train_wrenformer(
     # folds=(ensemble_size, slurm_array_task_id),
     epochs=epochs,
     checkpoint="wandb",  # None | 'local' | 'wandb',
-    input_col=MbdKey.wyckoff_spglib,
+    input_col=MbdKey.protostructure_spglib,
     learning_rate=learning_rate,
     batch_size=batch_size,
     wandb_path=WANDB_PATH,

--- a/scripts/evals/geo_opt.py
+++ b/scripts/evals/geo_opt.py
@@ -37,9 +37,11 @@ df_dft_analysis = pd.read_csv(DataFiles.wbm_dft_geo_opt_symprec_1e_5.path, index
 init_spg_col = "init_spg_num"
 dft_spg_col = "dft_spg_num"
 df_wbm[init_spg_col] = (
-    df_wbm[MbdKey.init_wyckoff_spglib].str.split("_").str[2].astype(int)
+    df_wbm[MbdKey.init_protostructure_spglib].str.split("_").str[2].astype(int)
 )
-df_wbm[dft_spg_col] = df_wbm[MbdKey.wyckoff_spglib].str.split("_").str[2].astype(int)
+df_wbm[dft_spg_col] = (
+    df_wbm[MbdKey.protostructure_spglib].str.split("_").str[2].astype(int)
+)
 model_lvl, metric_lvl = "model", "metric"
 
 

--- a/site/src/routes/data/data-files-direct-download.md
+++ b/site/src/routes/data/data-files-direct-download.md
@@ -23,7 +23,7 @@ assert tuple(df_wbm) == (
     "e_form_per_atom_wbm",
     "e_above_hull_wbm",
     "bandgap_pbe",
-    "wyckoff_spglib_initial_structure",
+    "protostructure_spglib_initial_structure",
     "uncorrected_energy_from_cse",
     "e_correction_per_atom_mp2020",
     "e_correction_per_atom_mp_legacy",
@@ -31,7 +31,7 @@ assert tuple(df_wbm) == (
     "e_form_per_atom_mp2020_corrected",
     "e_above_hull_mp2020_corrected_ppd_mp",
     "site_stats_fingerprint_init_final_norm_diff",
-    "wyckoff_spglib",
+    "protostructure_spglib",
     "unique_prototype"
 )
 
@@ -51,8 +51,8 @@ assert len(wbm_init_atoms) == 256_963
 1. **`uncorrected_energy`**: Raw VASP-computed energy
 1. **`e_form_per_atom_wbm`**: Original formation energy per atom from [WBM paper]
 1. **`e_above_hull_wbm`**: Original energy above the convex hull in (eV/atom) from [WBM paper]
-1. **`wyckoff_spglib`**: Aflow label strings built from spacegroup and Wyckoff positions of the DFT-relaxed structure as computed by [spglib](https://spglib.readthedocs.io/en/stable/api/python-api.html#spglib.spglib.get_symmetry_dataset).
-1. **`wyckoff_spglib_initial_structure`**: Same as `wyckoff_spglib` but computed from the initial structure.
+1. **`protostructure_spglib`**: Aflow label strings built from spacegroup and Wyckoff positions of the DFT-relaxed structure as computed by [spglib](https://spglib.readthedocs.io/en/stable/api/python-api.html#spglib.spglib.get_symmetry_dataset).
+1. **`protostructure_spglib_initial_structure`**: Same as `protostructure_spglib` but computed from the initial structure.
 1. **`bandgap_pbe`**: PBE-level DFT band gap from [WBM paper]
 1. **`uncorrected_energy_from_cse`**: Uncorrected DFT energy stored in `ComputedStructureEntries`. Should be the same as `uncorrected_energy`. There are 2 cases where the absolute difference reported in the summary file and in the computed structure entries exceeds 0.1 eV (`wbm-2-3218`, `wbm-1-56320`) which we attribute to rounding errors.
 1. **`e_form_per_atom_uncorrected`**: Uncorrected DFT formation energy per atom in eV/atom.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -64,7 +64,12 @@ def test_df_wbm() -> None:
     assert df_wbm.index.name == Key.mat_id
     assert set(df_wbm) > {Key.formula, Key.mat_id, Key.bandgap_pbe}
 
-    for col in (MbdKey.e_form_dft, MbdKey.each_true):
+    for col in (
+        MbdKey.e_form_dft,
+        MbdKey.each_true,
+        MbdKey.init_protostructure_spglib,
+        MbdKey.protostructure_spglib,
+    ):
         assert col in df_wbm, f"{col=} not in {list(df_wbm)=}"
 
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -38,6 +38,10 @@ def test_mbd_key() -> None:
     )
     assert MbdKey.each_true == "e_above_hull_mp2020_corrected_ppd_mp"
     assert MbdKey.each_true.label == "E<sub>MP hull dist</sub>"
+    assert MbdKey.init_protostructure_spglib == (
+        "protostructure_spglib_initial_structure"
+    )
+    assert MbdKey.protostructure_spglib == "protostructure_spglib"
 
     # Test that all keys have values and labels
     for key in MbdKey:
@@ -180,6 +184,7 @@ def test_data_files_enum() -> None:
 
     # Test that paths are constructed correctly
     assert DataFiles.mp_energies.rel_path == "mp/2025-02-01-mp-energies.csv.gz"
+    assert DataFiles.mp_patched_phase_diagram.rel_path == "mp/2023-02-07-ppd-mp.pkl.gz"
     assert DataFiles.mp_energies.name == "mp_energies"
     assert DataFiles.mp_energies.url.startswith("https://figshare.com/files/")
 


### PR DESCRIPTION
- Renames WBM and MP protostructure column access from legacy `wyckoff_spglib` names to `protostructure_spglib`.
- Updates the tracked WBM summary data, source links, checksums, and Figshare metadata for the renamed columns.
- Refreshes model analyses, evaluation scripts, and tests to use the updated data sources and column names.
- Keeps the published MP `PatchedPhaseDiagram` pickle because it preserves the serialized entry data required by pymatgen.

Closes #131