### PR TITLE
Add active field and remove commenting out in enum

### DIFF
--- a/matbench_discovery/cli.py
+++ b/matbench_discovery/cli.py
@@ -31,7 +31,7 @@ cli_parser.add_argument(
 
 cli_parser.add_argument(
     "--models",
-    nargs="*",
+    nargs="+",
     type=parse_model,
     choices=Model,
     default=list(Model.active()),
@@ -117,4 +117,4 @@ if cli_args.auto_download:
 if cli_args.no_show:
     import plotly.graph_objects as go
 
-    go.Figure.show = lambda *_args, **_kwargs: None
+    go.Figure.show = lambda *_args, **_kwargs: None  # ty: ignore[invalid-assignment]

--- a/matbench_discovery/cli.py
+++ b/matbench_discovery/cli.py
@@ -34,8 +34,8 @@ cli_parser.add_argument(
     nargs="*",
     type=parse_model,
     choices=Model,
-    default=list(Model),
-    help="Models to analyze. If none specified, analyzes all models.",
+    default=list(Model.active()),
+    help="Models to analyze. If none specified, analyzes active models.",
 )
 cli_parser.add_argument(
     "--debug",
@@ -117,4 +117,4 @@ if cli_args.auto_download:
 if cli_args.no_show:
     import plotly.graph_objects as go
 
-    go.Figure.show = lambda *_args, **_kwargs: None  # ty: ignore[invalid-assignment]
+    go.Figure.show = lambda *_args, **_kwargs: None

--- a/matbench_discovery/cli.py
+++ b/matbench_discovery/cli.py
@@ -34,7 +34,7 @@ cli_parser.add_argument(
     nargs="+",
     type=parse_model,
     choices=Model,
-    default=list(Model.active()),
+    default=None,
     help="Models to analyze. If none specified, analyzes active models.",
 )
 cli_parser.add_argument(
@@ -108,6 +108,8 @@ plot_group.add_argument(
     help="Suppress Plotly figures from opening in browser.",
 )
 cli_args, _ignore_unknown = cli_parser.parse_known_args()
+if cli_args.models is None:
+    cli_args.models = list(Model.active())
 
 # Set env var to auto-confirm file downloads when --auto-download is passed
 if cli_args.auto_download:

--- a/matbench_discovery/cli.py
+++ b/matbench_discovery/cli.py
@@ -34,7 +34,7 @@ cli_parser.add_argument(
     nargs="+",
     type=parse_model,
     choices=Model,
-    default=None,
+    default=list(Model.active()),
     help="Models to analyze. If none specified, analyzes active models.",
 )
 cli_parser.add_argument(
@@ -108,8 +108,6 @@ plot_group.add_argument(
     help="Suppress Plotly figures from opening in browser.",
 )
 cli_args, _ignore_unknown = cli_parser.parse_known_args()
-if cli_args.models is None:
-    cli_args.models = list(Model.active())
 
 # Set env var to auto-confirm file downloads when --auto-download is passed
 if cli_args.auto_download:

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -96,7 +96,7 @@ def glob_to_df(
             df_mock = pd.read_csv(f"{TEST_FILES}/mock-wbm-energy-preds.csv.gz")
             # .set_index( "material_id" )
             # make sure pred_cols for all models are present in df_mock
-            for model in Model.active():
+            for model in Model:
                 with open(model.yaml_path, encoding="utf-8") as file:
                     model_data = yaml.safe_load(file)
 
@@ -214,7 +214,7 @@ df_wbm.index = df_wbm[str(Key.mat_id)]
 
 def load_df_wbm_with_preds(
     *,
-    models: Sequence[str | Model] = (),
+    models: Sequence[str | Model] | None = None,
     pbar: bool = True,
     id_col: str = Key.mat_id,
     subset: pd.Index | Sequence[str] | TestSubset | None = None,
@@ -224,8 +224,9 @@ def load_df_wbm_with_preds(
     """Load WBM summary dataframe with model predictions from disk.
 
     Args:
-        models (Sequence[str], optional): Model names must be keys of
-            matbench_discovery.data.Model. Defaults to active models.
+        models (Sequence[str | Model] | None, optional): Models to load, given as
+            Model members, enum names, or display labels. Defaults to active models
+            when None. Pass an empty sequence to load no model predictions.
         pbar (bool, optional): Whether to show progress bar. Defaults to True.
         id_col (str, optional): Column to set as df.index. Defaults to "material_id".
         subset (pd.Index | Sequence[str] | 'uniq_protos' | None, optional):
@@ -247,25 +248,31 @@ def load_df_wbm_with_preds(
     Returns:
         pd.DataFrame: WBM summary dataframe with model predictions.
     """
-    valid_models = {model.name for model in Model}
-    if models == ():
-        models = Model.active()
-    inv_label_map = {key.label: key.name for key in Model}
-    # map pretty model names back to Model enum keys
-    models = [inv_label_map.get(model, model) for model in models]
-    if unknown_models := ", ".join(set(models) - valid_models):
-        raise ValueError(f"{unknown_models=}, expected subset of {valid_models}")
+    if models is None:
+        models_to_load = Model.active()
+    else:
+        model_lookup = {model.name: model for model in Model} | {
+            model.label: model for model in Model
+        }
+        try:
+            models_to_load = tuple(
+                model if isinstance(model, Model) else model_lookup[model]
+                for model in models
+            )
+        except KeyError as exc:
+            valid_models = {model.name for model in Model}
+            raise ValueError(
+                f"unknown model {exc.args[0]!r}, expected subset of {valid_models}"
+            ) from exc
 
-    model_name: str = ""
+    model_name = ""
     df_out = df_wbm.copy()
 
     try:
-        prog_bar = tqdm(models, disable=not pbar, desc="Loading preds")
-        for model_name in prog_bar:
+        prog_bar = tqdm(models_to_load, disable=not pbar, desc="Loading preds")
+        for model in prog_bar:
+            model_name = model.name
             prog_bar.set_postfix_str(model_name)
-
-            # use getattr(name) in case model_name is already a Model enum
-            model = Model[getattr(model_name, "name", model_name)]
 
             df_preds = glob_to_df(model.discovery_path, pbar=False, **kwargs)
 

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -251,19 +251,25 @@ def load_df_wbm_with_preds(
     if models is None:
         models_to_load = Model.active()
     else:
-        model_lookup = {model.name: model for model in Model} | {
-            model.label: model for model in Model
-        }
-        try:
-            models_to_load = tuple(
-                model if isinstance(model, Model) else model_lookup[model]
-                for model in models
-            )
-        except KeyError as exc:
-            valid_models = {model.name for model in Model}
-            raise ValueError(
-                f"unknown model {exc.args[0]!r}, expected subset of {valid_models}"
-            ) from exc
+        resolved_models: list[Model] = []
+        for model_ref in models:
+            if isinstance(model_ref, Model):
+                resolved_models.append(model_ref)
+                continue
+            model = Model.__members__.get(model_ref)
+            if model is None:
+                model = Model._missing_(model_ref)
+            if model is None:
+                model = next(
+                    (model for model in Model if model.label == model_ref), None
+                )
+            if model is None:
+                valid_models = {model.name for model in Model}
+                raise ValueError(
+                    f"unknown model {model_ref!r}, expected subset of {valid_models}"
+                )
+            resolved_models.append(model)
+        models_to_load = tuple(resolved_models)
 
     model_name = ""
     df_out = df_wbm.copy()

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -96,7 +96,7 @@ def glob_to_df(
             df_mock = pd.read_csv(f"{TEST_FILES}/mock-wbm-energy-preds.csv.gz")
             # .set_index( "material_id" )
             # make sure pred_cols for all models are present in df_mock
-            for model in Model:
+            for model in Model.active():
                 with open(model.yaml_path, encoding="utf-8") as file:
                     model_data = yaml.safe_load(file)
 
@@ -225,7 +225,7 @@ def load_df_wbm_with_preds(
 
     Args:
         models (Sequence[str], optional): Model names must be keys of
-            matbench_discovery.data.Model. Defaults to all models.
+            matbench_discovery.data.Model. Defaults to active models.
         pbar (bool, optional): Whether to show progress bar. Defaults to True.
         id_col (str, optional): Column to set as df.index. Defaults to "material_id".
         subset (pd.Index | Sequence[str] | 'uniq_protos' | None, optional):
@@ -249,7 +249,7 @@ def load_df_wbm_with_preds(
     """
     valid_models = {model.name for model in Model}
     if models == ():
-        models = tuple(valid_models)
+        models = Model.active()
     inv_label_map = {key.label: key.name for key in Model}
     # map pretty model names back to Model enum keys
     models = [inv_label_map.get(model, model) for model in models]

--- a/matbench_discovery/enums.py
+++ b/matbench_discovery/enums.py
@@ -273,6 +273,7 @@ class Model(Files, base_dir=f"{ROOT}/models"):
 
     # AlphaNet: https://arxiv.org/abs/2501.07155
     alphanet_v1_oam = auto(), "alphanet/alphanet-v1-oam.yml"
+    alphanet_mptrj = auto(), "alphanet/alphanet-mptrj.yml"
     # alignn with global pooling: https://arxiv.org/abs/2106.01829
     alignn = auto(), "alignn/alignn.yml"
 
@@ -300,10 +301,10 @@ class Model(Files, base_dir=f"{ROOT}/models"):
     # DeePMD-DPA3 models: https://arxiv.org/abs/2506.01686
     dpa_3_1_mptrj = auto(), "deepmd/dpa-3.1-mptrj.yml"
     dpa_3_1_3m_ft = auto(), "deepmd/dpa-3.1-3m-ft.yml"
-    # dpa3_v2_mptrj = auto(), "deepmd/dpa3-v2-mptrj.yml"
-    # dpa3_v2_openlam = auto(), "deepmd/dpa3-v2-openlam.yml"
-    # dpa3_v1_mptrj = auto(), "deepmd/dpa3-v1-mptrj.yml"
-    # dpa3_v1_openlam = auto(), "deepmd/dpa3-v1-openlam.yml"
+    dpa3_v2_mptrj = auto(), "deepmd/dpa3-v2-mptrj.yml"
+    dpa3_v2_openlam = auto(), "deepmd/dpa3-v2-openlam.yml"
+    dpa3_v1_mptrj = auto(), "deepmd/dpa3-v1-mptrj.yml"
+    dpa3_v1_openlam = auto(), "deepmd/dpa3-v1-openlam.yml"
 
     # FAIR-Chem
     eqv2_s_dens_mp = auto(), "eqV2/eqV2-s-dens-mp.yml"
@@ -340,7 +341,7 @@ class Model(Files, base_dir=f"{ROOT}/models"):
     mace_mpa_0 = auto(), "mace/mace-mpa-0.yml"  # trained on MPtrj and Alexandria
 
     # MatRIS
-    # matris_v050_mptrj = auto(), "matris/matris-v050-mptrj.yml"
+    matris_v050_mptrj = auto(), "matris/matris-v050-mptrj.yml"
     matris_10m_oam = auto(), "matris/matris-10m-oam.yml"
     matris_10m_mp = auto(), "matris/matris-10m-mp.yml"
 
@@ -365,13 +366,13 @@ class Model(Files, base_dir=f"{ROOT}/models"):
     pet_oam_xl_1_0_0 = auto(), "pet/pet-oam-xl-1.0.0.yml"
 
     # SevenNet trained on MPtrj
-    # sevennet_0 = auto(), "sevennet/sevennet-0.yml"
+    sevennet_0 = auto(), "sevennet/sevennet-0.yml"
     sevennet_l3i5 = auto(), "sevennet/sevennet-l3i5.yml"
-    # sevennet_mf_ompa = auto(), "sevennet/sevennet-mf-ompa.yml"
+    sevennet_mf_ompa = auto(), "sevennet/sevennet-mf-ompa.yml"
     sevennet_omni_i12 = auto(), "sevennet/sevennet-omni-i12.yml"
 
     # Tensor Atomic Cluster Expansion
-    # tace_v1_oam_m = auto(), "tace/tace-v1-oam-m.yml"
+    tace_v1_oam_m = auto(), "tace/tace-v1-oam-m.yml"
     tace_oam_l = auto(), "tace/tace-oam-l.yml"
 
     # Magpie composition+Voronoi tessellation structure features + sklearn random forest
@@ -506,6 +507,16 @@ class Model(Files, base_dir=f"{ROOT}/models"):
     def is_complete(self) -> bool:
         """Check if model has all required metrics."""
         return self.metadata.get("status", "complete") == "complete"
+
+    @property
+    def is_active(self) -> bool:
+        """Check if model should be included in default benchmark runs."""
+        return self.is_complete
+
+    @classmethod
+    def active(cls) -> tuple[Self, ...]:
+        """Models included by default in plots, metrics, and eval scripts."""
+        return tuple(model for model in cls if model.is_active)
 
     @classmethod
     def _missing_(cls, value: object) -> Self | None:

--- a/matbench_discovery/enums.py
+++ b/matbench_discovery/enums.py
@@ -508,15 +508,10 @@ class Model(Files, base_dir=f"{ROOT}/models"):
         """Check if model has all required metrics."""
         return self.metadata.get("status", "complete") == "complete"
 
-    @property
-    def is_active(self) -> bool:
-        """Check if model should be included in default benchmark runs."""
-        return self.is_complete
-
     @classmethod
     def active(cls) -> tuple[Self, ...]:
-        """Models included by default in plots, metrics, and eval scripts."""
-        return tuple(model for model in cls if model.is_active)
+        """Complete models included by default in plots, metrics, and eval scripts."""
+        return tuple(model for model in cls if model.is_complete)
 
     @classmethod
     def _missing_(cls, value: object) -> Self | None:

--- a/matbench_discovery/preds/discovery.py
+++ b/matbench_discovery/preds/discovery.py
@@ -14,7 +14,7 @@ __date__ = "2023-02-04"
 
 
 # load WBM summary dataframe with all models' formation energy predictions (eV/atom)
-models_to_load = cli_args.models or list(Model)
+models_to_load = cli_args.models or Model.active()
 df_preds = load_df_wbm_with_preds(models=models_to_load).round(3)
 
 

--- a/matbench_discovery/preds/discovery.py
+++ b/matbench_discovery/preds/discovery.py
@@ -5,7 +5,7 @@ from pymatviz.enums import Key
 
 from matbench_discovery import STABILITY_THRESHOLD
 from matbench_discovery.cli import cli_args
-from matbench_discovery.data import Model, df_wbm, load_df_wbm_with_preds
+from matbench_discovery.data import df_wbm, load_df_wbm_with_preds
 from matbench_discovery.enums import MbdKey
 from matbench_discovery.metrics.discovery import stable_metrics
 
@@ -14,7 +14,7 @@ __date__ = "2023-02-04"
 
 
 # load WBM summary dataframe with all models' formation energy predictions (eV/atom)
-models_to_load = cli_args.models or Model.active()
+models_to_load = cli_args.models
 df_preds = load_df_wbm_with_preds(models=models_to_load).round(3)
 
 

--- a/matbench_discovery/preds/discovery.py
+++ b/matbench_discovery/preds/discovery.py
@@ -14,7 +14,7 @@ __date__ = "2023-02-04"
 
 
 # load WBM summary dataframe with all models' formation energy predictions (eV/atom)
-models_to_load = cli_args.models
+models_to_load = tuple(model for model in cli_args.models if model.is_complete)
 df_preds = load_df_wbm_with_preds(models=models_to_load).round(3)
 
 
@@ -73,11 +73,11 @@ for model in models_to_load:
 
 
 # pick F1 as primary metric to sort by
-df_metrics = df_metrics.round(3).sort_values("F1", axis=1, ascending=False)
-df_metrics_10k = df_metrics_10k.round(3).sort_values("F1", axis=1, ascending=False)
-df_metrics_uniq_protos = df_metrics_uniq_protos.round(3).sort_values(
-    "F1", axis=1, ascending=False
-)
+df_metrics = df_metrics.round(3)
+df_metrics_10k = df_metrics_10k.round(3)
+df_metrics_uniq_protos = df_metrics_uniq_protos.round(3)
+for metrics in (df_metrics, df_metrics_10k, df_metrics_uniq_protos):
+    metrics.sort_values("F1", axis=1, ascending=False, inplace=True)  # noqa: PD002
 
 # dataframe of all models' energy above convex hull (EACH) predictions (eV/atom)
 df_each_pred = pd.DataFrame()

--- a/scripts/evals/diatomic_metrics.py
+++ b/scripts/evals/diatomic_metrics.py
@@ -7,12 +7,11 @@ import sys
 
 from matbench_discovery import ROOT
 from matbench_discovery.cli import cli_args
-from matbench_discovery.enums import Model
 from matbench_discovery.metrics import diatomics
 from matbench_discovery.metrics.diatomics import DiatomicCurves
 from matbench_discovery.remote.fetch import maybe_auto_download_file
 
-models_to_evaluate = cli_args.models or Model.active()
+models_to_evaluate = cli_args.models
 print(f"Evaluating diatomic metrics for {len(models_to_evaluate)} model(s)...")
 
 n_success = 0

--- a/scripts/evals/diatomic_metrics.py
+++ b/scripts/evals/diatomic_metrics.py
@@ -12,7 +12,7 @@ from matbench_discovery.metrics import diatomics
 from matbench_discovery.metrics.diatomics import DiatomicCurves
 from matbench_discovery.remote.fetch import maybe_auto_download_file
 
-models_to_evaluate = cli_args.models or list(Model)
+models_to_evaluate = cli_args.models or Model.active()
 print(f"Evaluating diatomic metrics for {len(models_to_evaluate)} model(s)...")
 
 n_success = 0

--- a/scripts/evals/discovery.py
+++ b/scripts/evals/discovery.py
@@ -31,13 +31,18 @@ __date__ = "2022-11-28"
 
 # %%
 if __name__ == "__main__":
+    for model in cli_args.models:
+        if not model.is_complete:
+            print(f"\nSkipping {model.label}: incomplete discovery metrics")
+    cli_args.models = [model for model in cli_args.models if model.is_complete]
+    if not cli_args.models:
+        raise SystemExit(0)
+
     import matbench_discovery.preds.discovery as preds
 
     uniq_protos_idx = df_wbm.query(MbdKey.uniq_proto).index
 
-    models_to_write = cli_args.models
-
-    for model in models_to_write:
+    for model in cli_args.models:
         try:
             print(f"\nProcessing {model.label}...")
             model_preds = preds.df_preds[model.label]

--- a/scripts/evals/discovery.py
+++ b/scripts/evals/discovery.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     uniq_protos_idx = df_wbm.query(MbdKey.uniq_proto).index
 
-    models_to_write = cli_args.models or list(Model)
+    models_to_write = cli_args.models or Model.active()
 
     for model in models_to_write:
         try:

--- a/scripts/evals/discovery.py
+++ b/scripts/evals/discovery.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     uniq_protos_idx = df_wbm.query(MbdKey.uniq_proto).index
 
-    models_to_write = cli_args.models or Model.active()
+    models_to_write = cli_args.models
 
     for model in models_to_write:
         try:
@@ -216,7 +216,7 @@ for model_label in models:
         )
 
         for key in (MbdKey.openness, Key.train_task, Key.test_task):
-            default = {MbdKey.openness: Open.OSOD}.get(key, pd.NA)
+            default = Open.OSOD if key == MbdKey.openness else pd.NA
             discovery.df_metrics_uniq_protos.loc[key.label, model] = model.metadata.get(
                 key, default
             )
@@ -343,7 +343,7 @@ for (label, df_met), show_non_compliant in itertools.product(
         dict.fromkeys(df_table.select_dtypes(float), "{:,.3f}"),  # use for manuscript
         na_rep="",  # render NaNs as empty string
     )
-    styler = styler.background_gradient(
+    styler = styler.background_gradient(  # ty: ignore[unresolved-attribute]
         cmap="viridis", subset=list(higher_is_better & {*df_table}), axis="index"
     ).background_gradient(  # reverse color map if lower=better
         cmap="viridis_r", subset=list(lower_is_better & {*df_table}), axis="index"

--- a/scripts/evals/geo_opt.py
+++ b/scripts/evals/geo_opt.py
@@ -48,10 +48,7 @@ model_lvl, metric_lvl = "model", "metric"
 # %% Load all model data
 model_data: dict[str, pd.DataFrame] = {}
 model_metrics: dict[str, dict[str, float]] = {}
-for model in Model:
-    if not model.is_complete:  # Skip incomplete models
-        continue
-
+for model in Model.active():
     metrics = model.metadata.get("metrics", {}).get("geo_opt", {})
     if not isinstance(metrics, dict) or not (pred_file := metrics.get("pred_file")):
         continue

--- a/scripts/evals/kappa.py
+++ b/scripts/evals/kappa.py
@@ -20,14 +20,15 @@ def main() -> int:
     Returns:
         Exit code: 0 if at least one model was evaluated, 1 otherwise.
     """
-    models_to_evaluate = cli_args.models or list(Model)
+    models_to_evaluate = cli_args.models or Model.active()
     print(f"Evaluating kappa metrics for {len(models_to_evaluate)} model(s)...")
 
     n_success = 0
     n_skipped = 0
 
     for model in models_to_evaluate:
-        if not os.path.isfile(model.kappa_103_path or ""):
+        kappa_103_path = model.kappa_103_path
+        if not isinstance(kappa_103_path, str) or not os.path.isfile(kappa_103_path):
             print(f"Skipping {model.label}: no kappa_103_path found")
             n_skipped += 1
             continue
@@ -36,7 +37,7 @@ def main() -> int:
             print(f"\nProcessing {model.label}...")
 
             # Load and process data
-            df_ml = pd.read_json(model.kappa_103_path).set_index(Key.mat_id)
+            df_ml = pd.read_json(kappa_103_path).set_index(Key.mat_id)
             df_dft = pd.read_json(DataFiles.phonondb_pbe_103_kappa_no_nac.path)
             if "mp_id" in df_dft.columns:
                 df_dft = df_dft.rename(columns={"mp_id": Key.mat_id})
@@ -51,7 +52,7 @@ def main() -> int:
 
             # Update YAML file
             metrics_dict = {"srme": kappa_srme, "sre": kappa_sre}
-            phonons.write_metrics_to_yaml(model, metrics_dict, model.kappa_103_path)
+            phonons.write_metrics_to_yaml(model, metrics_dict, kappa_103_path)
             print(f"\tUpdated {model.yaml_path}")
             n_success += 1
 

--- a/scripts/evals/kappa.py
+++ b/scripts/evals/kappa.py
@@ -10,7 +10,7 @@ import pandas as pd
 from pymatviz.enums import Key
 
 from matbench_discovery.cli import cli_args
-from matbench_discovery.enums import DataFiles, Model
+from matbench_discovery.enums import DataFiles
 from matbench_discovery.metrics import phonons
 
 
@@ -20,7 +20,7 @@ def main() -> int:
     Returns:
         Exit code: 0 if at least one model was evaluated, 1 otherwise.
     """
-    models_to_evaluate = cli_args.models or Model.active()
+    models_to_evaluate = cli_args.models
     print(f"Evaluating kappa metrics for {len(models_to_evaluate)} model(s)...")
 
     n_success = 0

--- a/tests/metrics/test_discovery_metrics.py
+++ b/tests/metrics/test_discovery_metrics.py
@@ -205,7 +205,7 @@ def test_stable_metrics() -> None:
 
 def test_df_discovery_metrics() -> None:
     """Test df_metrics dataframe is valid."""
-    missing_cols = {*discovery.df_metrics} - {model.label for model in Model}
+    missing_cols = {*discovery.df_metrics} - {model.label for model in Model.active()}
     assert missing_cols == set(), f"{missing_cols=}"
     assert discovery.df_metrics.T.MAE.between(0, 0.2).all(), (
         f"unexpected {discovery.df_metrics.T.MAE=}"

--- a/tests/metrics/test_discovery_metrics.py
+++ b/tests/metrics/test_discovery_metrics.py
@@ -1,4 +1,7 @@
 import math
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -217,6 +220,31 @@ def test_df_discovery_metrics() -> None:
         f"unexpected {discovery.df_metrics.T.RMSE=}"
     )
     assert discovery.df_metrics.T.isna().sum().sum() == 0, "NaNs in metrics"
+
+
+def test_discovery_eval_skips_incomplete_cli_model() -> None:
+    """Test discovery eval skips incomplete CLI models before writing metrics."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evals/discovery.py",
+            "--models",
+            "alphanet-mptrj",
+            "--no-show",
+        ],
+        cwd=f"{Path(__file__).parents[2]}",
+        env=os.environ | {"CI": "1"},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+
+    assert result.returncode == 0, output
+    assert "Skipping AlphaNet-v1-MPtrj: incomplete discovery metrics" in output
+    assert "Loading preds" not in output
+    assert "Error processing" not in output
+    assert "KeyError" not in output
 
 
 def test_write_metrics_to_yaml(tmp_path: Path) -> None:

--- a/tests/metrics/test_discovery_metrics.py
+++ b/tests/metrics/test_discovery_metrics.py
@@ -205,7 +205,7 @@ def test_stable_metrics() -> None:
 
 def test_df_discovery_metrics() -> None:
     """Test df_metrics dataframe is valid."""
-    missing_cols = {*discovery.df_metrics} - {model.label for model in Model.active()}
+    missing_cols = {model.label for model in Model.active()} - set(discovery.df_metrics)
     assert missing_cols == set(), f"{missing_cols=}"
     assert discovery.df_metrics.T.MAE.between(0, 0.2).all(), (
         f"unexpected {discovery.df_metrics.T.MAE=}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from matbench_discovery.enums import Model, TestSubset
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ([], {"models": list(Model.active()), "test_subset": TestSubset.uniq_protos}),
+        ([], {"models": None, "test_subset": TestSubset.uniq_protos}),
         (["--models", str(Model.chgnet_030)], {"models": [Model.chgnet_030]}),
         (
             ["--models", "alphanet-mptrj"],
@@ -39,7 +39,7 @@ from matbench_discovery.enums import Model, TestSubset
     ],
 )
 def test_cli_parser(
-    args: list[str], expected: dict[str, str | bool | TestSubset | list[Model]]
+    args: list[str], expected: dict[str, str | bool | None | TestSubset | list[Model]]
 ) -> None:
     """Test CLI argument parsing with various inputs."""
     with patch.object(sys, "argv", ["script.py", *args]):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,10 @@ from matbench_discovery.enums import Model, TestSubset
         ([], {"models": list(Model.active()), "test_subset": TestSubset.uniq_protos}),
         (["--models", str(Model.chgnet_030)], {"models": [Model.chgnet_030]}),
         (
+            ["--models", "alphanet-mptrj"],
+            {"models": [Model.alphanet_mptrj]},
+        ),
+        (
             [
                 "--models",
                 str(Model.chgnet_030),
@@ -47,6 +51,7 @@ def test_cli_parser(
 @pytest.mark.parametrize(
     "bad_args",
     [
+        ["--models"],
         ["--models", "invalid_model"],
         ["--test-subset", "invalid_subset"],
         ["--energy-type", "invalid_type"],
@@ -59,7 +64,7 @@ def test_cli_parser_invalid_args(
     with pytest.raises(SystemExit), patch.object(sys, "argv", ["script.py", *bad_args]):
         cli_parser.parse_known_args()
 
-    if bad_args[0] == "--models":
+    if bad_args == ["--models", "invalid_model"]:
         error = capsys.readouterr().err
         assert "invalid model: invalid_model" in error
         assert "None" not in error

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,5 @@
 """Test CLI argument parsing module."""
 
-import sys
-from unittest.mock import patch
-
 import pytest
 from pymatviz.enums import Key
 
@@ -13,7 +10,7 @@ from matbench_discovery.enums import Model, TestSubset
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ([], {"models": None, "test_subset": TestSubset.uniq_protos}),
+        ([], {"models": list(Model.active()), "test_subset": TestSubset.uniq_protos}),
         (["--models", str(Model.chgnet_030)], {"models": [Model.chgnet_030]}),
         (
             ["--models", "alphanet-mptrj"],
@@ -39,13 +36,12 @@ from matbench_discovery.enums import Model, TestSubset
     ],
 )
 def test_cli_parser(
-    args: list[str], expected: dict[str, str | bool | None | TestSubset | list[Model]]
+    args: list[str], expected: dict[str, str | bool | TestSubset | list[Model]]
 ) -> None:
     """Test CLI argument parsing with various inputs."""
-    with patch.object(sys, "argv", ["script.py", *args]):
-        parsed_args, _ = cli_parser.parse_known_args()
-        for key, val in expected.items():
-            assert getattr(parsed_args, key) == val
+    parsed_args, _ = cli_parser.parse_known_args(args)
+    for key, val in expected.items():
+        assert getattr(parsed_args, key) == val
 
 
 @pytest.mark.parametrize(
@@ -61,8 +57,8 @@ def test_cli_parser_invalid_args(
     bad_args: list[str], capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Test CLI parser raises SystemExit on invalid arguments."""
-    with pytest.raises(SystemExit), patch.object(sys, "argv", ["script.py", *bad_args]):
-        cli_parser.parse_known_args()
+    with pytest.raises(SystemExit):
+        cli_parser.parse_known_args(bad_args)
 
     if bad_args == ["--models", "invalid_model"]:
         error = capsys.readouterr().err
@@ -78,12 +74,11 @@ def test_cli_parser_jupyter_compat() -> None:
         "--models",
         str(Model.chgnet_030),
     ]
-    with patch.object(sys, "argv", ["script.py", *jupyter_args]):
-        args, unknown = cli_parser.parse_known_args()
-        # Our args should be parsed correctly
-        assert args.models == [Model.chgnet_030]
-        # Jupyter args should be preserved but ignored
-        assert set(unknown) == {"--f=/path/to/kernel.json", "--ip=127.0.0.1"}
+    args, unknown = cli_parser.parse_known_args(jupyter_args)
+    # Our args should be parsed correctly
+    assert args.models == [Model.chgnet_030]
+    # Jupyter args should be preserved but ignored
+    assert set(unknown) == {"--f=/path/to/kernel.json", "--ip=127.0.0.1"}
 
 
 def test_cli_args_global() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from matbench_discovery.enums import Model, TestSubset
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ([], {"models": list(Model), "test_subset": TestSubset.uniq_protos}),
+        ([], {"models": list(Model.active()), "test_subset": TestSubset.uniq_protos}),
         (["--models", str(Model.chgnet_030)], {"models": [Model.chgnet_030]}),
         (
             [

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -282,6 +282,30 @@ def test_load_df_wbm_with_preds(
             assert df_wbm_with_preds[model.label].isna().sum() == 0
 
 
+def test_load_df_wbm_with_preds_mock_data_models() -> None:
+    """Test default and explicit model loading with pytest mock data."""
+    inactive_model_refs = (
+        Model.alphanet_mptrj,
+        Model.alphanet_mptrj.name,
+        Model.alphanet_mptrj.label,
+    )
+    with patch("matbench_discovery.data.glob", return_value=[]):
+        df_default = load_df_wbm_with_preds(pbar=False)
+        inactive_cols = [
+            list(load_df_wbm_with_preds(models=[model_ref], pbar=False))
+            for model_ref in inactive_model_refs
+        ]
+
+    default_cols = list(df_default)
+    assert default_cols == [*df_wbm, *(model.label for model in Model.active())]
+    assert set(default_cols).isdisjoint(
+        model.label for model in Model if not model.is_complete
+    )
+    assert inactive_cols == [[*df_wbm, Model.alphanet_mptrj.label]] * len(
+        inactive_model_refs
+    )
+
+
 @pytest.mark.skipif(
     "CI" in os.environ, reason="CI uses mock data where other error thresholds apply"
 )

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -370,7 +370,7 @@ def test_model_prediction_urls() -> None:
     import multiprocessing as mp
 
     tasks: dict[str, str] = {}
-    for model in Model:
+    for model in Model.active():
         if model.name == Model.mace_mpa_0.name:
             continue
         tasks[model.pr_url] = model.name

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,6 +115,8 @@ def test_model_enum() -> None:
     # Test model properties that don't depend on file existence
     assert Model.mace_mp_0.label == "MACE-MP-0"
     assert Model.mace_mp_0.name == Model.mace_mp_0.value == "mace_mp_0"
+    assert Model.active() == tuple(model for model in Model if model.is_complete)
+    assert not Model.alphanet_mptrj.is_complete
 
 
 @pytest.mark.parametrize(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -109,6 +109,7 @@ def test_model_enum() -> None:
     # Skip file existence checks in CI environment
     for model in Model:
         assert os.path.isfile(model.yaml_path)
+    for model in Model.active():
         assert "/models/" in model.discovery_path
 
     # Test model properties that don't depend on file existence


### PR DESCRIPTION
PR #324's approach of commenting out the old model broke a legacy script that referenced the enum. This keeps all models in the enum and introduces an `active` flag so analyses, plots, CLI, and evaluation workflows default to complete production-ready models.

- Registers `alphanet_mptrj`, DeepMD DPA3 variants, `matris_v050_mptrj`, SevenNet variants, and `tace_v1_oam_m`.
- Treats an unspecified CLI model selection as “none,” which triggers the active-model default.
- Updates tests for the new selection behavior.