### PR TITLE
Document WBM ground-truth provenance

### DIFF
--- a/data/wbm/readme.md
+++ b/data/wbm/readme.md
@@ -32,6 +32,16 @@ The full set of processing steps used to curate the WBM test set from the raw da
 - apply the [`MaterialsProject2020Compatibility`](https://github.com/materialsproject/pymatgen/blob/02a4ca8aa/pymatgen/entries/compatibility.py#L823) energy correction scheme to the formation energies
 - compute energy to the Materials Project convex hull constructed from all MP `ComputedStructureEntries` queried on 2023-02-07 ([database release 2022.10.28](https://docs.materialsproject.org/changes/database-versions#v2022.10.28))
 
+> Provenance note: exact regeneration of the released
+> `e_form_per_atom_mp2020_corrected` and
+> `e_above_hull_mp2020_corrected_ppd_mp` columns depends on the `pymatgen`
+> `MaterialsProject2020Compatibility` implementation used to assign MP2020 anion
+> corrections. The released WBM summary is reproducible with 2023-era `pymatgen`
+> behavior (for example v2023.5.10, matching the data-file registry source
+> links). Newer `pymatgen` versions may assign different corrections for a small
+> number of structures with ambiguous oxidation states, which can change their
+> corrected formation energies and hull distances.
+
 Invoking the script `python compile_wbm_test_set.py` will auto-download and regenerate the WBM test set files from scratch. If you find
 
 - any questionable structures or data records in the released test set, or

--- a/matbench_discovery/data-files.yml
+++ b/matbench_discovery/data-files.yml
@@ -68,7 +68,7 @@ wbm_initial_atoms:
 wbm_summary:
   url: https://figshare.com/files/64706751
   path: wbm/2023-12-13-wbm-summary.csv.gz
-  description: Computed material properties only, no structures. Available properties are VASP energy, formation energy, energy above the convex hull, volume, band gap, number of sites per unit cell, and more.
+  description: Computed material properties only, no structures. Available properties are VASP energy, formation energy, energy above the convex hull, volume, band gap, number of sites per unit cell, and more. Exact regeneration of the MP2020-corrected formation energy and hull-distance columns depends on the `pymatgen` `MaterialsProject2020Compatibility` behavior used for anion-correction assignment; the released values are reproducible with v2023.5.10-era behavior.
   md5: 1555268d3aa59d20262cb9d01ce0994b
 
 wbm_dft_geo_opt_symprec_1e_2:

--- a/site/src/routes/data/data-files-direct-download.md
+++ b/site/src/routes/data/data-files-direct-download.md
@@ -62,6 +62,13 @@ assert len(wbm_init_atoms) == 256_963
 1. **`e_above_hull_mp2020_corrected_ppd_mp`**: Energy above hull distances in eV/atom after applying the MP2020 correction scheme. The convex hull in question is the one spanned by all ~145k Materials Project `ComputedStructureEntries`. Matbench Discovery takes these as ground truth for material stability. Any value above 0 is assumed to be an unstable/metastable material.
 1. **`site_stats_fingerprint_init_final_norm_diff`**: The norm of the difference between the initial and final site fingerprints. This is a volume-independent measure of how much the structure changed during DFT relaxation. Uses the `matminer` [`SiteStatsFingerprint`](https://github.com/hackingmaterials/matminer/blob/33bf1120/matminer/featurizers/structure/sites.py#L21-L33) (v0.8.0).
 
+> Exact regeneration of the MP2020-corrected formation-energy and hull-distance
+> columns depends on the `pymatgen` `MaterialsProject2020Compatibility` behavior
+> used for anion-correction assignment. The released WBM summary is reproducible
+> with 2023-era behavior (for example v2023.5.10, matching the data-file
+> registry source links); newer `pymatgen` versions may assign different
+> corrections for a small number of structures with ambiguous oxidation states.
+
 [`MaterialsProject2020Compatibility`]: https://github.com/materialsproject/pymatgen/blob/02a4ca8aa/pymatgen/entries/compatibility.py#L823
 [`MaterialsProjectCompatibility`]: https://github.com/materialsproject/pymatgen/blob/02a4ca8aa/pymatgen/entries/compatibility.py#L766
 


### PR DESCRIPTION
Following up on #358 with the smallest docs-only provenance note.

This is not a model submission. It documents that exact regeneration of the released WBM ground-truth columns depends on the `pymatgen` `MaterialsProject2020Compatibility` behavior used for MP2020 anion-correction assignment.

The note is intentionally narrow:

- the released `e_form_per_atom_mp2020_corrected` and `e_above_hull_mp2020_corrected_ppd_mp` columns are reproducible with 2023-era `pymatgen` behavior, e.g. v2023.5.10;
- newer `pymatgen` versions may assign different anion corrections for a small number of ambiguous-oxidation-state structures;
- this can change corrected formation energies and hull distances when users re-derive the WBM summary from the published CSEs.

Changed locations:

- `data/wbm/readme.md`: provenance note near the WBM processing steps.
- `site/src/routes/data/data-files-direct-download.md`: matching note near the WBM summary column descriptions.
- `matbench_discovery/data-files.yml`: shorter note in the `wbm_summary` description, so the generated data-file list carries the same caveat.

## Relation to #358

This implements the docs/provenance option from #358 without changing data files, checksums, or runtime behavior.