### PR TITLE
Register ema-gnn as archived direct discovery predictor

### DIFF
--- a/matbench_discovery/discovery.py
+++ b/matbench_discovery/discovery.py
@@ -57,6 +57,7 @@ ARCHIVED_DISCOVERY_MODELS: dict[str, str] = {
             "bowsr",
             "cgcnn",
             "cgcnn_p",
+            "ema_gnn",
             "esnet",
             "megnet",
             "voronoi_rf",


### PR DESCRIPTION
Prerequisite for an upcoming EMA-GNN model submission (IS2E, targets E, direct formation-energy predictor without an ASE calculator).

Adds ema_gnn to the existing ARCHIVED_DISCOVERY_MODELS block whose shared reason is "archived direct predictor without an ASE calculator" — the same category as alignn, cgcnn, esnet, megnet and the other IS2E entries.

Without this, test_runnable_models_have_reproducible_runners fails for any active model with a pred_file that isn't in CALCULATORS or ARCHIVED_DISCOVERY_MODELS.

The model submission PR will follow once this is merged.