### PR TITLE
Share runner/eval scaffolding and document every module on the API page

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   build:
     if: ${{ !github.event.pull_request.head.repo.fork }}
+    env:
+      PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
+      PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
     defaults:
       run:
         working-directory: site
@@ -37,8 +40,6 @@ jobs:
 
       - name: Install dependencies
         # use the project's pinned pnpm (packageManager field) via corepack
-        env:
-          PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
         run: corepack enable && pnpm install
 
       - name: Download parity assets

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Build site
         run: |
-          uv run --with-editable .. ../scripts/make_api_docs.py
+          # API docs import phono3py at module scope.
+          uv run --with-editable "..[phonons]" ../scripts/make_api_docs.py
           pnpm run build
 
       - name: Upload build artifact

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,9 +15,6 @@ permissions:
 jobs:
   build:
     if: ${{ !github.event.pull_request.head.repo.fork }}
-    env:
-      PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
-      PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
     defaults:
       run:
         working-directory: site
@@ -40,6 +37,10 @@ jobs:
 
       - name: Install dependencies
         # use the project's pinned pnpm (packageManager field) via corepack
+        env:
+          # MatterViz currently references the reviewed svelte-widgets git dependency.
+          PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
+          PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
         run: corepack enable && pnpm install
 
       - name: Download parity assets

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,6 @@ permissions:
 
 jobs:
   prek:
-    env:
-      PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
-      PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -28,6 +25,10 @@ jobs:
 
       - name: Install site dependencies
         # use the project's pinned pnpm (packageManager field) via corepack
+        env:
+          # MatterViz currently references the reviewed svelte-widgets git dependency.
+          PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
+          PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
         run: corepack enable && pnpm install
         working-directory: site
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   prek:
+    env:
+      PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
+      PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -25,8 +28,6 @@ jobs:
 
       - name: Install site dependencies
         # use the project's pinned pnpm (packageManager field) via corepack
-        env:
-          PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
         run: corepack enable && pnpm install
         working-directory: site
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,6 @@ jobs:
       install-cmd: uv pip install -e .[test,symmetry] --system
 
   vitest:
-    env:
-      PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
-      PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
     defaults:
       run:
         working-directory: site
@@ -56,6 +53,10 @@ jobs:
 
       - name: Install dependencies
         # use the project's pinned pnpm (packageManager field) via corepack
+        env:
+          # MatterViz currently references the reviewed svelte-widgets git dependency.
+          PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
+          PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
         run: corepack enable && pnpm install
 
       - name: Run unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
       install-cmd: uv pip install -e .[test,symmetry] --system
 
   vitest:
+    env:
+      PNPM_CONFIG_BLOCK_EXOTIC_SUBDEPS: "false"
+      PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
     defaults:
       run:
         working-directory: site
@@ -53,8 +56,6 @@ jobs:
 
       - name: Install dependencies
         # use the project's pinned pnpm (packageManager field) via corepack
-        env:
-          PNPM_CONFIG_DANGEROUSLY_ALLOW_ALL_BUILDS: "true"
         run: corepack enable && pnpm install
 
       - name: Run unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  release:
-    types: [published]
+  # release.yml calls this workflow, avoiding a duplicate release-triggered run
   workflow_dispatch:
     inputs:
       task:

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ models/**/*.json*
 # WIP model submissions
 models/_*
 
-# auto-generated docs
-site/src/routes/api/*.md
+# generated API module docs
+site/src/routes/api/modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.2
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.65
+    rev: v0.0.69
     hooks:
       - id: ty
         # --isolated: don't create/update uv.lock or the local .venv
@@ -80,7 +80,7 @@ repos:
         exclude: changelog\.md$
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
       - id: check-jsonschema
         name: check-jsonschema-models
@@ -97,7 +97,7 @@ repos:
       - id: check-github-workflows
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.48.0
+    rev: v1.49.0
     hooks:
       - id: typos
         stages: [pre-commit, commit-msg]

--- a/data/mp/get_mp_energies.py
+++ b/data/mp/get_mp_energies.py
@@ -140,7 +140,7 @@ df_elem_refs = pd.DataFrame(docs).set_index(Key.mat_id, drop=False)
 df_elem_refs[Key.atomic_number] = [Element(el).Z for el in df_elem_refs["chemsys"]]
 df_elem_refs[potcar_spec_key] = [
     ", ".join(
-        potcar["titel"]  # codespell:ignore
+        potcar["titel"]  # VASP's own (misspelled) POTCAR field name
         for potcar in next(iter(entry.values())).parameters["potcar_spec"]
     )
     for entry in df_elem_refs["entries"]

--- a/matbench_discovery/calculators.py
+++ b/matbench_discovery/calculators.py
@@ -23,6 +23,7 @@ from ase.calculators.calculator import Calculator
 from filelock import FileLock
 
 from matbench_discovery import DEFAULT_CACHE_DIR
+from matbench_discovery.data import file_sha256
 
 CHECKPOINT_DIR = f"{DEFAULT_CACHE_DIR}/md-checkpoints"
 # generous: AOTInductor exports (TACE) compile every kernel ahead of time
@@ -34,15 +35,6 @@ def _is_non_empty_file(path: str) -> bool:
     return os.path.isfile(path) and os.path.getsize(path) > 0
 
 
-def _file_sha256(path: str) -> str:
-    """Return a file's SHA-256 digest."""
-    digest = hashlib.sha256()
-    with open(path, mode="rb") as file:
-        for chunk in iter(lambda: file.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
 def _file_state(path: str) -> tuple[int, int, int]:
     """Return cheap fields that change whenever normal file writes occur."""
     file_stat = os.stat(path)
@@ -52,7 +44,7 @@ def _file_state(path: str) -> tuple[int, int, int]:
 def _stable_file_sha256(path: str) -> tuple[str, tuple[int, int, int]]:
     """Hash a file outside locks and reject concurrent mutation."""
     state = _file_state(path)
-    digest = _file_sha256(path)
+    digest = file_sha256(path)
     if _file_state(path) != state:
         raise RuntimeError(f"File changed while hashing: {path}")
     return digest, state
@@ -216,7 +208,7 @@ def _run_to_atomic_output(
                 _file_state(path) != state for path, _digest, state in source_identities
             ):
                 raise RuntimeError(f"Source changed while creating {dest}")
-            output_hash = _file_sha256(tmp_dest)
+            output_hash = file_sha256(tmp_dest)
             os.replace(tmp_dest, dest)
             with open(identity_path, mode="w", encoding="utf-8") as file:
                 file.write(f"{recipe_hash}\n{output_hash}")

--- a/matbench_discovery/data.py
+++ b/matbench_discovery/data.py
@@ -17,7 +17,7 @@ import os
 import re
 import sys
 import zipfile
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from datetime import date
 from decimal import Decimal, InvalidOperation
 from functools import cache
@@ -32,6 +32,7 @@ from ase import Atoms
 from filelock import FileLock
 from pymatviz.enums import Key
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
 from tqdm import tqdm
 
 from matbench_discovery import DATA_DIR, TEST_FILES
@@ -71,6 +72,23 @@ _FILE_REF_KEYS: Final = frozenset(
 # Tasks that require forces (not applicable when targets == "E")
 FORCE_TASKS: Final = frozenset({"geo_opt", "phonons", "md", "diatomics"})
 _COVERAGE_META_KEYS: Final = frozenset({"status", "reason"})
+
+
+def file_sha256(path: str) -> str:
+    """Stream a file into a SHA-256 digest."""
+    with open(path, mode="rb") as file:
+        return hashlib.file_digest(file, "sha256").hexdigest()
+
+
+def commented_map_with_units(
+    mapping: Mapping[str, Any], units: Mapping[str, str]
+) -> CommentedMap:
+    """Build a YAML block with unit comments on matching keys."""
+    block = CommentedMap(mapping)
+    for key in block:
+        if unit := units.get(key):
+            block.yaml_add_eol_comment(unit, key, column=1)
+    return block
 
 
 class FileRef(TypedDict):

--- a/matbench_discovery/metrics/discovery.py
+++ b/matbench_discovery/metrics/discovery.py
@@ -262,9 +262,7 @@ def write_all_metrics_to_yaml(
     Replaces every subset block (dropping deprecated rate keys) and removes
     obsolete siblings like most_stable_10k; keeps pred_file and cost provenance.
     """
-    from ruamel.yaml.comments import CommentedMap
-
-    from matbench_discovery.data import update_yaml_file
+    from matbench_discovery.data import commented_map_with_units, update_yaml_file
 
     units = {
         "MAE": "eV/atom",
@@ -283,14 +281,9 @@ def write_all_metrics_to_yaml(
     }
     written: dict[TestSubset, dict[str, str | float]] = {}
     for test_subset, metrics in metrics_by_subset.items():
-        block = CommentedMap(
-            {key: round(float(value), 3) for key, value in metrics.items()}
-        )
-        block[str(MbdKey.missing_preds)] = n_missing[test_subset]
-        for key, unit in units.items():
-            if key in block:
-                block.yaml_add_eol_comment(unit, key, column=1)
-        written[test_subset] = block
+        rounded = {key: round(float(value), 3) for key, value in metrics.items()}
+        rounded[str(MbdKey.missing_preds)] = n_missing[test_subset]
+        written[test_subset] = commented_map_with_units(rounded, units)
 
     # Metric subset blocks always carry F1; pred_file / hardware do not.
     update_yaml_file(

--- a/matbench_discovery/metrics/geo_opt.py
+++ b/matbench_discovery/metrics/geo_opt.py
@@ -2,11 +2,11 @@
 
 import pandas as pd
 from pymatviz.enums import Key
-from ruamel.yaml.comments import CommentedMap
 
 from matbench_discovery import repo_relative_path
 from matbench_discovery.data import (
     canonical_scientific_notation,
+    commented_map_with_units,
     make_file_ref,
     update_yaml_file,
 )
@@ -52,11 +52,7 @@ def write_metrics_to_yaml(
         str(Key.n_structures): int(df_geo_opt[Key.n_structures].iloc[0]),
         "analysis_file": make_file_ref(analysis_file_path),
     }
-    metrics_for_symprec = CommentedMap(metrics_for_symprec)
-    symprec_key = f"symprec={canonical_scientific_notation(symprec)}"
-
-    # Define units for metrics
-    metric_units = {
+    metric_units: dict[str, str] = {
         Key.rmsd: "unitless",
         Key.n_sym_ops_mae: "unitless",
         Key.symmetry_decrease: "fraction",
@@ -64,10 +60,8 @@ def write_metrics_to_yaml(
         Key.symmetry_increase: "fraction",
         Key.n_structures: "count",
     }
-    # Add units as YAML end-of-line comments
-    for key in metrics_for_symprec:
-        if unit := metric_units.get(key):
-            metrics_for_symprec.yaml_add_eol_comment(unit, key, column=1)
+    metrics_for_symprec = commented_map_with_units(metrics_for_symprec, metric_units)
+    symprec_key = f"symprec={canonical_scientific_notation(symprec)}"
 
     update_yaml_file(
         model.yaml_path, f"metrics.geo_opt.{symprec_key}", metrics_for_symprec

--- a/matbench_discovery/metrics/md.py
+++ b/matbench_discovery/metrics/md.py
@@ -19,10 +19,13 @@ import pandas as pd
 from ase import Atoms, units
 from ase.data import atomic_masses, covalent_radii
 from ase.geometry import find_mic, get_distances, minkowski_reduce
-from ruamel.yaml.comments import CommentedMap
 
 from matbench_discovery import repo_relative_path
-from matbench_discovery.data import make_file_ref, update_yaml_file
+from matbench_discovery.data import (
+    commented_map_with_units,
+    make_file_ref,
+    update_yaml_file,
+)
 from matbench_discovery.hpc import COST_PROVENANCE_KEYS
 from matbench_discovery.trajectory import Trajectory
 
@@ -776,21 +779,18 @@ def write_metrics_to_yaml(
     """Write model-level MD metrics from calc_md_metrics to the metrics.md section
     of a model YAML file, with unit comments and optional pred_file references.
     """
-    yaml_metrics = CommentedMap()
+    block: dict[str, Any] = {}
     if pred_file_path is not None:
         relative_path = repo_relative_path(pred_file_path)
-        yaml_metrics["pred_file"] = make_file_ref(relative_path, url=pred_file_url)
+        block["pred_file"] = make_file_ref(relative_path, url=pred_file_url)
     elif pred_file_url is not None:
         raise ValueError("pred_file_url requires pred_file_path")
     for key, value in metrics.items():
         if key == "n_systems":
-            yaml_metrics[key] = int(value)
-        elif isinstance(value, str):  # e.g. hardware
-            yaml_metrics[key] = value
+            block[key] = int(value)
         else:
-            yaml_metrics[key] = float(round(value, 4))
-        if unit := METRIC_UNITS.get(key):
-            yaml_metrics.yaml_add_eol_comment(unit, key, column=1)
+            block[key] = value if isinstance(value, str) else float(round(value, 4))
+    yaml_metrics = commented_map_with_units(block, METRIC_UNITS)
 
     update_yaml_file(model.yaml_path, "metrics.md", yaml_metrics)
     return yaml_metrics

--- a/matbench_discovery/phonons/adapters/__init__.py
+++ b/matbench_discovery/phonons/adapters/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from matbench_discovery.phonons.adapters.standard import (
     FairchemKappaAdapter,
-    RelaxationResult,
     StandardKappaAdapter,
 )
 
@@ -22,10 +21,3 @@ def get_kappa_adapter(model_key: str) -> StandardKappaAdapter:
     if model_key.startswith(("eqv2_", "esen_", "equiformer_v3_")):
         return FairchemKappaAdapter()
     return StandardKappaAdapter()
-
-
-__all__ = [
-    "RelaxationResult",
-    "StandardKappaAdapter",
-    "get_kappa_adapter",
-]

--- a/matbench_discovery/phonons/pipeline.py
+++ b/matbench_discovery/phonons/pipeline.py
@@ -29,6 +29,7 @@ from tqdm import tqdm
 
 from matbench_discovery import ROOT
 from matbench_discovery.ase_relax import canonical_filter_name, canonical_optimizer_name
+from matbench_discovery.data import file_sha256
 from matbench_discovery.enums import DataFiles, Model
 from matbench_discovery.hpc import (
     detect_hardware,
@@ -367,12 +368,6 @@ class KappaArtifacts:
 def material_id_digest(material_ids: Sequence[str]) -> str:
     """Return an order-sensitive digest for the canonical dataset ID sequence."""
     return hashlib.sha256("\n".join(map(str, material_ids)).encode()).hexdigest()
-
-
-def file_sha256(path: str) -> str:
-    """Stream a file into a SHA-256 digest."""
-    with open(path, mode="rb") as file:
-        return hashlib.file_digest(file, "sha256").hexdigest()
 
 
 def checkpoint_digest(checkpoint: str | None) -> str | None:

--- a/matbench_discovery/remote/__init__.py
+++ b/matbench_discovery/remote/__init__.py
@@ -1,0 +1,1 @@
+"""Remote data access: file downloads and the Figshare upload API."""

--- a/matbench_discovery/runner_cli.py
+++ b/matbench_discovery/runner_cli.py
@@ -4,12 +4,61 @@ from __future__ import annotations
 
 import glob
 import os
-import shlex
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import argparse
     from collections.abc import Mapping, Sequence
+
+
+def add_common_runner_args(
+    parser: argparse.ArgumentParser,
+    *,
+    dry_run_help: str,
+    out_dir_help: str = "Defaults to models/<arch>/<model>",
+    list_models_help: str = "Print registered models and exit",
+) -> argparse.ArgumentParser:
+    """Add the model-selection and dependency-isolation flags every runner shares."""
+    parser.add_argument("--model", help="Calculator key, model key, or model label")
+    parser.add_argument("--list-models", action="store_true", help=list_models_help)
+    parser.add_argument(
+        "--print-cmd",
+        action="store_true",
+        help="Print the dependency-isolated uv command and exit",
+    )
+    parser.add_argument("--dry-run", action="store_true", help=dry_run_help)
+    parser.add_argument("--out-dir", help=out_dir_help)
+    parser.add_argument(
+        "--dtype",
+        choices=("float64", "float32"),
+        default="float64",
+        help="Calculator float precision. default float64",
+    )
+    return parser
+
+
+def add_shard_args(
+    parser: argparse.ArgumentParser, *, merge_shards_help: str, write_yaml_help: str
+) -> None:
+    """Add the merge/shard flags that sharded runners layer on the common flags."""
+    parser.add_argument("--merge-shards", action="store_true", help=merge_shards_help)
+    parser.add_argument("--write-yaml", action="store_true", help=write_yaml_help)
+    parser.add_argument("--shard-dir", help="Override the resumable shard directory")
+    parser.add_argument(
+        "--device", choices=("cpu", "cuda"), help="Calculator device. default auto"
+    )
+    parser.add_argument(
+        "--n-shards",
+        type=int,
+        help="Number of atom-balanced shards; defaults to Slurm task count or 1. "
+        "When rerunning a subset of shards, pass the original value so task IDs "
+        "keep their original shard indices",
+    )
+    parser.add_argument(
+        "--shard-index",
+        type=int,
+        help="Zero-based shard index; defaults to normalized Slurm array task ID",
+    )
 
 
 def resolve_sharded_prefix(
@@ -51,11 +100,6 @@ def dependency_run_args(
         f"--{flag}" for flag in flags if getattr(args, flag.replace("-", "_"))
     )
     return run_args
-
-
-def print_dependency_command(command: Sequence[str]) -> None:
-    """Print a dependency-isolated command with shell-safe quoting."""
-    print(shlex.join(command))
 
 
 def validate_sharded_write_args(

--- a/matbench_discovery/structure/__init__.py
+++ b/matbench_discovery/structure/__init__.py
@@ -1,0 +1,1 @@
+"""Crystal structure analysis: AFLOW prototype labels and symmetry detection."""

--- a/models/run_diatomics.py
+++ b/models/run_diatomics.py
@@ -27,6 +27,7 @@ import argparse
 import gzip
 import json
 import os
+import shlex
 import time
 from glob import glob
 
@@ -53,7 +54,7 @@ from matbench_discovery.metrics.diatomics.exclusions import (
     get_excluded_formula_reasons,
     is_non_mp_formula,
 )
-from matbench_discovery.runner_cli import dependency_run_args, print_dependency_command
+from matbench_discovery.runner_cli import add_common_runner_args, dependency_run_args
 
 module_dir = os.path.dirname(__file__)
 
@@ -88,22 +89,10 @@ def trim_curve_to_finite(formula: str, curve: CurveDict) -> CurveDict | None:
 
 def main() -> int:
     """Parse args and run (or dry-run) the diatomic curve sweep for one model."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", help="Model key, see --list-models")
-    parser.add_argument(
-        "--list-models", action="store_true", help="Print registered models and exit"
+    parser = add_common_runner_args(
+        argparse.ArgumentParser(description=__doc__),
+        dry_run_help="Smoke test: a few elements at a few distances",
     )
-    parser.add_argument(
-        "--print-cmd",
-        action="store_true",
-        help="Print the 'uv run --with ...' command for --model and exit",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Smoke test: a few elements at a few distances",
-    )
-    parser.add_argument("--out-dir", help="Defaults to models/<arch>/<model>")
     parser.add_argument(
         "--max-z",
         type=int,
@@ -118,12 +107,6 @@ def main() -> int:
     )
     parser.add_argument(
         "--n-points", type=int, default=119, help="Number of log-spaced distances"
-    )
-    parser.add_argument(
-        "--dtype",
-        default="float64",
-        choices=("float64", "float32"),
-        help="Calculator float precision. default float64",
     )
     parser.add_argument(
         "--write-yaml",
@@ -165,8 +148,10 @@ def main() -> int:
             },
             ("dry-run", "merge-shards", "write-yaml"),
         )
-        print_dependency_command(
-            CALCULATORS[args.model].uv_run_cmd("models/run_diatomics.py", *run_args)
+        print(
+            shlex.join(
+                CALCULATORS[args.model].uv_run_cmd("models/run_diatomics.py", *run_args)
+            )
         )
         return 0
 
@@ -202,12 +187,7 @@ def main() -> int:
 
     if args.merge_shards:
         shard_metadatas: list[dict[str, object]] = []
-        expected_formulas = {
-            f"{chemical_symbols[z_value]}-{chemical_symbols[z_value]}"
-            for z_value in z_values
-        }
-        # normpath both sides: glob returns OS-native separators on Windows, which
-        # would never compare equal to the /-joined expected paths
+        # Normalize both sides because glob returns OS-native separators on Windows.
         expected_paths = [
             os.path.normpath(f"{shard_dir}/Z{z_value:03d}-diatomics.json.gz")
             for z_value in z_values
@@ -227,7 +207,10 @@ def main() -> int:
                 parser.error(f"Inconsistent distances in {shard_path}")
             curves.update(shard.get(homo_nuc, {}))
             shard_metadatas.append(shard.get("run_metadata", {}))
-
+        expected_formulas = {
+            f"{chemical_symbols[z_value]}-{chemical_symbols[z_value]}"
+            for z_value in z_values
+        }
         missing_formulas = {
             formula
             for formula in expected_formulas - set(curves)
@@ -304,10 +287,9 @@ def main() -> int:
             return 0
         from matbench_discovery.metrics import diatomics
 
-        pred_curves = diatomics.DiatomicCurves.from_dict(results)
         metrics = diatomics.calc_diatomic_metrics(
             ref_curves=diatomics.load_dft_reference_curves("PBE"),
-            pred_curves=pred_curves,
+            pred_curves=diatomics.DiatomicCurves.from_dict(results),
             interpolate=200,
         )
         metrics = drop_metric_exclusions(args.model, metrics)

--- a/models/run_discovery.py
+++ b/models/run_discovery.py
@@ -27,13 +27,14 @@ from __future__ import annotations
 import argparse
 import glob
 import os
+import shlex
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-from matbench_discovery import ROOT, today
+from matbench_discovery import repo_relative_path, today
 from matbench_discovery.calculators import (
     CALCULATORS,
     load_calculator,
@@ -58,12 +59,15 @@ from matbench_discovery.discovery import (
     write_discovery_artifacts,
 )
 from matbench_discovery.enums import Model
-from matbench_discovery.hpc import effective_shard_args as _effective_shard_args
-from matbench_discovery.hpc import partition_material_ids
-from matbench_discovery.hpc import slurm_shard_selection as _slurm_shard_selection
+from matbench_discovery.hpc import (
+    effective_shard_args,
+    partition_material_ids,
+    slurm_shard_selection,
+)
 from matbench_discovery.runner_cli import (
+    add_common_runner_args,
+    add_shard_args,
     dependency_run_args,
-    print_dependency_command,
     resolve_sharded_prefix,
     validate_sharded_write_args,
 )
@@ -73,57 +77,27 @@ module_dir = os.path.dirname(__file__)
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the discovery runner command-line parser."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", help="Calculator key, model key, or model label")
-    parser.add_argument(
-        "--list-models", action="store_true", help="Print registered calculators"
+    parser = add_common_runner_args(
+        argparse.ArgumentParser(description=__doc__),
+        dry_run_help="Relax four WBM structures for at most two optimizer steps",
     )
-    parser.add_argument(
-        "--print-cmd",
-        action="store_true",
-        help="Print the dependency-isolated uv command and exit",
+    add_shard_args(
+        parser,
+        merge_shards_help="Strictly merge complete shards and write final artifacts",
+        write_yaml_help=(
+            "On a complete merge, update artifact paths and discovery metrics"
+        ),
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Relax four WBM structures for at most two optimizer steps",
-    )
-    parser.add_argument(
-        "--merge-shards",
-        action="store_true",
-        help="Strictly merge complete shards and write final artifacts",
-    )
-    parser.add_argument(
-        "--write-yaml",
-        action="store_true",
-        help="On a complete merge, update artifact paths and discovery metrics",
-    )
-    parser.add_argument("--out-dir", help="Defaults to models/<arch>/<model>")
-    parser.add_argument("--shard-dir", help="Override the resumable shard directory")
     parser.add_argument("--pred-file", help="Override the final prediction CSV path")
     parser.add_argument(
         "--geo-opt-file", help="Override the final relaxed-structure JSONL path"
     )
-    parser.add_argument("--dtype", choices=("float64", "float32"), default="float64")
-    parser.add_argument("--device", choices=("cpu", "cuda"))
     parser.add_argument("--max-force", type=float)
     parser.add_argument("--max-steps", type=int)
     parser.add_argument("--ase-optimizer")
     parser.add_argument(
         "--cell-filter",
         help="ASE filter class name, or 'none' for fixed-cell relaxation",
-    )
-    parser.add_argument(
-        "--n-shards",
-        type=int,
-        help="Number of atom-balanced shards; defaults to Slurm task count or 1. "
-        "When rerunning a subset of shards, pass the original value so task IDs "
-        "keep their original shard indices",
-    )
-    parser.add_argument(
-        "--shard-index",
-        type=int,
-        help="Zero-based shard index; defaults to normalized Slurm array task ID",
     )
     return parser
 
@@ -185,12 +159,13 @@ def _print_cmd_args(args: argparse.Namespace, model_key: str) -> list[str]:
 
 def _repo_relative_path(path: str) -> str:
     """Return a repository-relative path, preserving external absolute paths."""
+    # resolve against the cwd (not ROOT) before the containment check, so a relative
+    # --out-dir keeps pointing at what the caller meant
     absolute_path = os.path.abspath(path)
     try:
-        relative_path = os.path.relpath(absolute_path, ROOT).replace("\\", "/")
-    except ValueError:  # Windows: path and repo root are on different drives
+        return repo_relative_path(absolute_path)
+    except ValueError:  # outside the repo (or a different Windows drive)
         return absolute_path
-    return relative_path if not relative_path.startswith("../") else absolute_path
 
 
 def _update_artifact_metadata(
@@ -270,7 +245,7 @@ def main(raw_args: Sequence[str] | None = None) -> int:
         command = CALCULATORS[model_key].uv_run_cmd(
             "models/run_discovery.py", *_print_cmd_args(args, model_key)
         )
-        print_dependency_command(command)
+        print(shlex.join(command))
         return 0
 
     try:
@@ -344,13 +319,13 @@ def main(raw_args: Sequence[str] | None = None) -> int:
         return 0
 
     try:
-        n_shards_arg, shard_index_arg, skip_task = _effective_shard_args(
+        n_shards_arg, shard_index_arg, skip_task = effective_shard_args(
             args.n_shards, args.shard_index, dry_run=args.dry_run
         )
         if skip_task:
             print("Skipping redundant dry run outside the first Slurm array task")
             return 0
-        n_shards, shard_index = _slurm_shard_selection(n_shards_arg, shard_index_arg)
+        n_shards, shard_index = slurm_shard_selection(n_shards_arg, shard_index_arg)
         atoms_by_id = load_wbm_atoms(model_key, dry_run=args.dry_run)
         shard_assignments = partition_material_ids(atoms_by_id, n_shards)
     except ValueError as exc:
@@ -361,9 +336,8 @@ def main(raw_args: Sequence[str] | None = None) -> int:
         material_id: atoms_by_id[material_id] for material_id in assigned_material_ids
     }
     shard_path = f"{shard_dir}/shard-{shard_index:03d}-of-{n_shards:03d}.jsonl"
-    calculator = load_calculator(model_key, device=args.device, dtype=args.dtype)
     shard = run_discovery_shard(
-        calculator=calculator,
+        calculator=load_calculator(model_key, device=args.device, dtype=args.dtype),
         model_key=model_key,
         atoms_by_id=atoms_by_id,
         assigned_material_ids=assigned_material_ids,

--- a/models/run_kappa.py
+++ b/models/run_kappa.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 from typing import TYPE_CHECKING
 
 from matbench_discovery import today
@@ -46,8 +47,9 @@ from matbench_discovery.phonons.pipeline import (
     write_kappa_artifacts,
 )
 from matbench_discovery.runner_cli import (
+    add_common_runner_args,
+    add_shard_args,
     dependency_run_args,
-    print_dependency_command,
     resolve_sharded_prefix,
     validate_sharded_write_args,
 )
@@ -58,22 +60,19 @@ if TYPE_CHECKING:
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the unified kappa command-line parser."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", help="Calculator key, model key, or model label")
-    parser.add_argument(
-        "--list-models",
-        action="store_true",
-        help="Print calculators with verified hyperparams.evaluation.kappa settings",
+    parser = add_common_runner_args(
+        argparse.ArgumentParser(description=__doc__),
+        dry_run_help="Run a bounded one-structure end-to-end smoke test",
+        list_models_help=(
+            "Print calculators with verified hyperparams.evaluation.kappa settings"
+        ),
     )
-    parser.add_argument(
-        "--print-cmd",
-        action="store_true",
-        help="Print the dependency-isolated uv command and exit",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Run a bounded one-structure end-to-end smoke test",
+    add_shard_args(
+        parser,
+        merge_shards_help="Strictly merge complete records and write final artifacts",
+        write_yaml_help=(
+            "On a complete 103-structure merge, update metrics and provenance"
+        ),
     )
     parser.add_argument(
         "--dry-run-size",
@@ -82,22 +81,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of structures retained by --dry-run",
     )
     parser.add_argument(
-        "--merge-shards",
-        action="store_true",
-        help="Strictly merge complete records and write final artifacts",
-    )
-    parser.add_argument(
-        "--write-yaml",
-        action="store_true",
-        help="On a complete 103-structure merge, update metrics and provenance",
-    )
-    parser.add_argument(
         "--retry-failures",
         action="store_true",
         help="Recompute existing records that contain a persisted error",
     )
-    parser.add_argument("--out-dir", help="Defaults to models/<arch>/<model>")
-    parser.add_argument("--shard-dir", help="Override the resumable run directory")
     parser.add_argument(
         "--dataset",
         help="Override the canonical PhononDB 103-structure extxyz path",
@@ -105,18 +92,6 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--checkpoint",
         help="Override the model checkpoint/artifact for supported calculators",
-    )
-    parser.add_argument("--dtype", choices=("float64", "float32"), default="float64")
-    parser.add_argument("--device", choices=("cpu", "cuda"))
-    parser.add_argument(
-        "--n-shards",
-        type=int,
-        help="Number of atom-balanced shards; defaults to Slurm task count or 1",
-    )
-    parser.add_argument(
-        "--shard-index",
-        type=int,
-        help="Zero-based shard index; defaults to normalized Slurm array task ID",
     )
     return parser
 
@@ -277,7 +252,7 @@ def main(raw_args: Sequence[str] | None = None) -> int:
         command = CALCULATORS[model_key].uv_run_cmd(
             "models/run_kappa.py", *print_cmd_args(args, model_key)
         )
-        print_dependency_command(command)
+        print(shlex.join(command))
         return 0
 
     out_dir = args.out_dir or os.path.splitext(model.yaml_path)[0]

--- a/models/run_md.py
+++ b/models/run_md.py
@@ -30,6 +30,7 @@ Model dependency trees conflict, so each model resolves its own environment via
 
 import argparse
 import os
+import shlex
 
 from matbench_discovery import today
 from matbench_discovery.calculators import (
@@ -39,29 +40,18 @@ from matbench_discovery.calculators import (
 )
 from matbench_discovery.data import artifact_filename
 from matbench_discovery.md import run_md_benchmark
-from matbench_discovery.runner_cli import dependency_run_args, print_dependency_command
+from matbench_discovery.runner_cli import add_common_runner_args, dependency_run_args
 
 module_dir = os.path.dirname(__file__)
 
 
 def main() -> int:
     """Parse args and run (or dry-run) the MD benchmark for one model."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", help="Model key, see --list-models")
-    parser.add_argument(
-        "--list-models", action="store_true", help="Print registered models and exit"
+    parser = add_common_runner_args(
+        argparse.ArgumentParser(description=__doc__),
+        dry_run_help="Smoke test: 1 system, a few MD steps, capped reference slice",
+        out_dir_help="Defaults to models/<arch>/<today>-md-nvt",
     )
-    parser.add_argument(
-        "--print-cmd",
-        action="store_true",
-        help="Print the 'uv run --with ...' command for --model and exit",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Smoke test: 1 system, a few MD steps, capped reference slice",
-    )
-    parser.add_argument("--out-dir", help="Defaults to models/<arch>/<today>-md-nvt")
     parser.add_argument(
         "--ref-file",
         help="Reference HDF5. Defaults to auto-downloaded DynaMat v1.0 set",
@@ -79,12 +69,6 @@ def main() -> int:
     parser.add_argument("--time-step-fs", type=float, default=0.25)
     parser.add_argument("--record-interval", type=int, default=10)
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument(
-        "--dtype",
-        default="float64",
-        choices=("float64", "float32"),
-        help="Calculator float precision. default float64",
-    )
     parser.add_argument(
         "--write-yaml", action="store_true", help="Write metrics to the model YAML"
     )
@@ -120,8 +104,10 @@ def main() -> int:
         )
         if args.systems is not None:
             run_args.extend(("--systems", *args.systems))
-        print_dependency_command(
-            CALCULATORS[args.model].uv_run_cmd("models/run_md.py", *run_args)
+        print(
+            shlex.join(
+                CALCULATORS[args.model].uv_run_cmd("models/run_md.py", *run_args)
+            )
         )
         return 0
 

--- a/scripts/evals/__init__.py
+++ b/scripts/evals/__init__.py
@@ -1,1 +1,32 @@
 """Evaluation scripts for Matbench Discovery."""
+
+import traceback
+from collections.abc import Callable, Sequence
+
+from matbench_discovery.enums import Model
+
+
+def evaluate_models(
+    task: str, models: Sequence[Model], evaluate_one: Callable[[Model], str | None]
+) -> int:
+    """Run one evaluator per model and report success."""
+    print(f"Evaluating {task} metrics for {len(models)} model(s)...")
+    n_success = 0
+    for model in models:
+        try:
+            skip_reason = evaluate_one(model)
+        except (ValueError, OSError, KeyError) as exc:
+            print(f"\tError processing {model.label}: {exc}")
+            traceback.print_exc()  # unexpected, so keep the full context
+            continue
+        if skip_reason is None:
+            n_success += 1
+        else:
+            print(f"Skipping {model.label}: {skip_reason}")
+
+    n_skipped = len(models) - n_success
+    if n_success == 0:
+        print(f"\nNo models evaluated successfully ({n_skipped} skipped)")
+        return 1
+    print(f"\nSuccessfully evaluated {n_success} model(s), {n_skipped} skipped")
+    return 0

--- a/scripts/evals/__init__.py
+++ b/scripts/evals/__init__.py
@@ -9,24 +9,29 @@ from matbench_discovery.enums import Model
 def evaluate_models(
     task: str, models: Sequence[Model], evaluate_one: Callable[[Model], str | None]
 ) -> int:
-    """Run one evaluator per model and report success."""
+    """Run one evaluator per model, returning 0 only if nothing failed.
+
+    Evaluators return a reason string to skip an expected gap. Selecting no models is
+    not a failure, but an unexpected error is, even when other models succeed.
+    """
     print(f"Evaluating {task} metrics for {len(models)} model(s)...")
-    n_success = 0
+    n_success = n_failed = 0
     for model in models:
         try:
             skip_reason = evaluate_one(model)
         except (ValueError, OSError, KeyError) as exc:
             print(f"\tError processing {model.label}: {exc}")
             traceback.print_exc()  # unexpected, so keep the full context
+            n_failed += 1
             continue
         if skip_reason is None:
             n_success += 1
         else:
             print(f"Skipping {model.label}: {skip_reason}")
 
-    n_skipped = len(models) - n_success
+    tally = f"{len(models) - n_success - n_failed} skipped, {n_failed} failed"
     if n_success == 0:
-        print(f"\nNo models evaluated successfully ({n_skipped} skipped)")
-        return 1
-    print(f"\nSuccessfully evaluated {n_success} model(s), {n_skipped} skipped")
-    return 0
+        print(f"\nNo models evaluated successfully ({tally})")
+    else:
+        print(f"\nSuccessfully evaluated {n_success} model(s), {tally}")
+    return 1 if n_failed or (len(models) > 0 and n_success == 0) else 0

--- a/scripts/evals/diatomic_metrics.py
+++ b/scripts/evals/diatomic_metrics.py
@@ -4,24 +4,18 @@ import gzip
 import json
 import numbers
 import os
-import sys
 
 from matbench_discovery import ROOT
 from matbench_discovery.cli import cli_args
 from matbench_discovery.data import file_ref_name, file_ref_url
-from matbench_discovery.enums import MbdKey
+from matbench_discovery.enums import MbdKey, Model
 from matbench_discovery.metrics import diatomics
 from matbench_discovery.metrics.diatomics import DiatomicCurves
 from matbench_discovery.metrics.diatomics.exclusions import drop_metric_exclusions
 from matbench_discovery.remote.fetch import maybe_auto_download_file
+from scripts.evals import evaluate_models
 
-models_to_evaluate = cli_args.models
-print(f"Evaluating diatomic metrics for {len(models_to_evaluate)} model(s)...")
-
-n_success = 0
-n_skipped = 0
-
-metrics_to_write: dict[str, dict[str, object]] = {
+METRICS_TO_WRITE: dict[str, dict[str, object]] = {
     metric: {}
     for metric in (
         MbdKey.tortuosity,
@@ -39,64 +33,55 @@ metrics_to_write: dict[str, dict[str, object]] = {
     )
 }
 
-pbe_ref_curves = diatomics.load_dft_reference_curves("PBE")
 
-for model in models_to_evaluate:
-    if not os.path.isfile(model.yaml_path):
-        print(f"Skipping {model.label}: YAML file not found")
-        n_skipped += 1
-        continue
+def main() -> int:
+    """Evaluate diatomic metrics, returning 0 if any model succeeds and 1 otherwise."""
+    pbe_ref_curves = diatomics.load_dft_reference_curves("PBE")
 
-    diatomics_metrics = model.metrics.get("diatomics") or {}
-    if not diatomics_metrics:
-        print(f"Skipping {model.label}: no diatomics metrics config in YAML")
-        n_skipped += 1
-        continue
+    def evaluate_one(model: Model) -> str | None:
+        if not os.path.isfile(model.yaml_path):
+            return "YAML file not found"
 
-    pred_name = file_ref_name(diatomics_metrics.get("pred_file"))
-    if pred_name is None:
-        print(f"Skipping {model.label}: no pred_file in diatomics config")
-        n_skipped += 1
-        continue
+        diatomics_metrics = model.metrics.get("diatomics") or {}
+        if not diatomics_metrics:
+            return "no diatomics metrics config in YAML"
 
-    abs_path = f"{ROOT}/{pred_name}"
-    pred_file_url = file_ref_url(diatomics_metrics.get("pred_file"))
+        pred_file = diatomics_metrics.get("pred_file")
+        pred_name = file_ref_name(pred_file)
+        if pred_name is None:
+            return "no pred_file in diatomics config"
 
-    # Try to download if file doesn't exist and URL is available
-    if not os.path.isfile(abs_path) and pred_file_url:
-        maybe_auto_download_file(
-            pred_file_url, abs_path, label=f"{model.label} diatomics"
+        prediction_path = f"{ROOT}/{pred_name}"
+        pred_file_url = file_ref_url(pred_file)
+
+        if not os.path.isfile(prediction_path) and pred_file_url:
+            maybe_auto_download_file(
+                pred_file_url, prediction_path, label=f"{model.label} diatomics"
+            )
+
+        if not os.path.isfile(prediction_path):
+            return f"prediction file not found at {pred_name}"
+
+        with gzip.open(prediction_path, mode="rb") as file:
+            pred_data = json.load(file) or {}
+
+        metrics = diatomics.calc_diatomic_metrics(
+            ref_curves=pbe_ref_curves,
+            pred_curves=DiatomicCurves.from_dict(pred_data),
+            metrics=METRICS_TO_WRITE,
+            interpolate=200,
         )
+        metrics = drop_metric_exclusions(model.name, metrics)
+        # Preserve source metadata by leaving run_metadata unset.
+        mean_metrics = diatomics.write_metrics_to_yaml(model, metrics)
+        print(f"{model.label}:")
+        for metric, value in mean_metrics.items():
+            value_str = f"{value:.5}" if isinstance(value, numbers.Real) else str(value)
+            print(f"  {metric}: {value_str}")
+        return None
 
-    if not os.path.isfile(abs_path):
-        print(f"Skipping {model.label}: prediction file not found at {pred_name}")
-        n_skipped += 1
-        continue
+    return evaluate_models("diatomic", cli_args.models, evaluate_one)
 
-    # Load predicted curves
-    with gzip.open(abs_path, mode="rb") as file:
-        pred_data = json.load(file) or {}
 
-    pred_curves = DiatomicCurves.from_dict(pred_data)
-
-    metrics = diatomics.calc_diatomic_metrics(
-        ref_curves=pbe_ref_curves,
-        pred_curves=pred_curves,
-        metrics=metrics_to_write,
-        interpolate=200,
-    )
-    metrics = drop_metric_exclusions(model.name, metrics)
-    # write_metrics_to_yaml preserves source run metadata (hardware, run time,
-    # excluded formula reasons) when we don't pass run_metadata
-    mean_metrics = diatomics.write_metrics_to_yaml(model, metrics)
-    print(f"{model.label}:")
-    for metric, val in mean_metrics.items():
-        value_str = f"{val:.5}" if isinstance(val, numbers.Real) else str(val)
-        print(f"  {metric}: {value_str}")
-    n_success += 1
-
-# Exit with error if no models were successfully evaluated
-if n_success == 0:
-    print(f"\nNo models evaluated successfully ({n_skipped} skipped)")
-    sys.exit(1)
-print(f"\nSuccessfully evaluated {n_success} model(s), {n_skipped} skipped")
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evals/discovery.py
+++ b/scripts/evals/discovery.py
@@ -4,38 +4,43 @@ The v1 paper's metric-table PDFs are frozen publication artifacts and intentiona
 do not track the evolving online leaderboard.
 """
 
-import traceback
-
 from matbench_discovery.cli import cli_args, complete_models
+from matbench_discovery.enums import Model
 from matbench_discovery.metrics import discovery
+from scripts.evals import evaluate_models
 
-if __name__ == "__main__":
+
+def main() -> int:
+    """Evaluate discovery metrics, returning 0 if any model succeeds and 1 otherwise."""
     models = complete_models()
     for model in cli_args.models:
         if model not in models:
             print(f"\nSkipping {model.label}: incomplete discovery metrics")
-    if not models:
-        raise SystemExit(0)
+    if not models:  # nothing selected has predictions, which is not an error
+        return 0
 
+    # deferred: loading every model's WBM predictions costs several GB
     from matbench_discovery.data import load_discovery_predictions
 
     df_preds, _df_each_pred, _df_each_err = load_discovery_predictions()
     uniq_proto_prevalence = discovery.wbm_uniq_proto_prevalence()
-    for model in models:
-        try:
-            print(f"\nProcessing {model.label}...")
-            metric_reference, model_preds = discovery.prepare_model_predictions(
-                df_preds, df_preds[model.label]
-            )
-            metrics_by_subset = discovery.calc_discovery_metrics(
-                metric_reference,
-                model_preds,
-                uniq_proto_prevalence=uniq_proto_prevalence,
-            )
-            discovery.write_all_metrics_to_yaml(
-                model, metrics_by_subset, metric_reference, model_preds
-            )
-            for test_subset in metrics_by_subset:
-                print(f"\tUpdated discovery metrics for {test_subset}")
-        except ValueError, OSError, KeyError:
-            print(f"\tError processing {model.label}: {traceback.format_exc()}")
+
+    def evaluate_one(model: Model) -> None:
+        print(f"\nProcessing {model.label}...")
+        metric_reference, model_preds = discovery.prepare_model_predictions(
+            df_preds, df_preds[model.label]
+        )
+        metrics_by_subset = discovery.calc_discovery_metrics(
+            metric_reference, model_preds, uniq_proto_prevalence=uniq_proto_prevalence
+        )
+        discovery.write_all_metrics_to_yaml(
+            model, metrics_by_subset, metric_reference, model_preds
+        )
+        for test_subset in metrics_by_subset:
+            print(f"\tUpdated discovery metrics for {test_subset}")
+
+    return evaluate_models("discovery", models, evaluate_one)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evals/kappa.py
+++ b/scripts/evals/kappa.py
@@ -2,7 +2,6 @@
 non-analytical correction term (NAC).
 """
 
-# %%
 import os
 
 from matbench_discovery.cli import cli_args

--- a/scripts/evals/kappa.py
+++ b/scripts/evals/kappa.py
@@ -6,60 +6,38 @@ non-analytical correction term (NAC).
 import os
 
 from matbench_discovery.cli import cli_args
+from matbench_discovery.enums import Model
 from matbench_discovery.metrics import phonons
 from matbench_discovery.phonons import read_kappa_json
+from scripts.evals import evaluate_models
+
+
+def evaluate_one(model: Model) -> str | None:
+    """Recompute one model's kappa metrics and update its YAML."""
+    kappa_103_path = model.kappa_103_path
+    if not kappa_103_path or not os.path.isfile(kappa_103_path):
+        return "no kappa_103_path found"
+
+    print(f"\nProcessing {model.label}...")
+    df_ml = read_kappa_json(kappa_103_path)
+    metrics = phonons.evaluate_kappa_predictions(df_ml)
+
+    for key in ("srme", "sre", "srd"):
+        print(f"\tκ_{key.upper()}={metrics[key]:.4f}")
+    print(f"\tκ failure rate={metrics['failure_rate']:.2%}")
+    print(f"\tImaginary-mode rate={metrics['imaginary_mode_rate']:.2%}")
+    spectrum_w1 = metrics["spectrum_w1"]
+    spectrum_w1_text = f"{spectrum_w1:.4f} THz" if spectrum_w1 is not None else "n/a"
+    print(f"\tSpectrum W1={spectrum_w1_text}")
+
+    phonons.write_metrics_to_yaml(model, metrics, kappa_103_path)
+    print(f"\tUpdated {model.yaml_path}")
+    return None
 
 
 def main() -> int:
-    """Evaluate kappa metrics and update model YAML files.
-
-    Returns:
-        Exit code: 0 if at least one model was evaluated, 1 otherwise.
-    """
-    models_to_evaluate = cli_args.models
-    print(f"Evaluating kappa metrics for {len(models_to_evaluate)} model(s)...")
-
-    n_success = 0
-
-    for model in models_to_evaluate:
-        kappa_103_path = model.kappa_103_path
-        if not isinstance(kappa_103_path, str) or not os.path.isfile(kappa_103_path):
-            print(f"Skipping {model.label}: no kappa_103_path found")
-            continue
-
-        try:
-            print(f"\nProcessing {model.label}...")
-
-            # Load and process data
-            df_ml = read_kappa_json(kappa_103_path)
-            metrics = phonons.evaluate_kappa_predictions(df_ml)
-
-            print(f"\tκ_SRME={metrics['srme']:.4f}")
-            print(f"\tκ_SRE={metrics['sre']:.4f}")
-            print(f"\tκ_SRD={metrics['srd']:.4f}")
-            print(f"\tκ failure rate={metrics['failure_rate']:.2%}")
-            print(f"\tImaginary-mode rate={metrics['imaginary_mode_rate']:.2%}")
-            spectrum_w1 = metrics["spectrum_w1"]
-            spectrum_w1_text = (
-                f"{spectrum_w1:.4f} THz" if spectrum_w1 is not None else "n/a"
-            )
-            print(f"\tSpectrum W1={spectrum_w1_text}")
-
-            # Recompute metrics while preserving the runner's artifact provenance.
-            phonons.write_metrics_to_yaml(model, metrics, kappa_103_path)
-            print(f"\tUpdated {model.yaml_path}")
-            n_success += 1
-
-        except (ValueError, OSError, KeyError) as exc:
-            print(f"\tError processing {model.label}: {exc}")
-
-    n_skipped = len(models_to_evaluate) - n_success
-    # Exit with error if no models were successfully evaluated
-    if n_success == 0:
-        print(f"\nNo models evaluated successfully ({n_skipped} skipped)")
-        return 1
-    print(f"\nSuccessfully evaluated {n_success} model(s), {n_skipped} skipped")
-    return 0
+    """Evaluate kappa metrics, returning 0 if any model succeeds and 1 otherwise."""
+    return evaluate_models("kappa", cli_args.models, evaluate_one)
 
 
 if __name__ == "__main__":

--- a/scripts/evals/md.py
+++ b/scripts/evals/md.py
@@ -12,18 +12,15 @@ from matbench_discovery.data import artifact_filename, file_ref_name, file_ref_u
 from matbench_discovery.enums import Model
 from matbench_discovery.md import default_md_reference_path, list_reference_systems
 from matbench_discovery.metrics import md as md_metrics
+from scripts.evals import evaluate_models
 
 
 def resolve_metrics(
     model: Model, md_yaml: dict[str, Any]
 ) -> tuple[pd.DataFrame, str, str | None, bool] | None:
-    """Load a model's per-system MD metrics indexed by system, or None to skip.
+    """Load per-system metrics when available, else the submitted combined CSV.
 
-    Prefers per-system CSVs from parallel single-system runs (combined into one frame);
-    falls back to the model's submitted combined CSV (``md_path``). Returns
-    ``(df_md, pred_file, pred_file_url, is_fresh_combine)``; ``is_fresh_combine`` flags
-    the combined-from-per-system case, whose CSV the caller persists after the coverage
-    check (and which carries no ``pred_file_url`` yet, so a stale one isn't reused).
+    The final return flag marks a fresh combination that the caller must persist.
     """
     arch_dir = os.path.dirname(model.rel_path)
     # one row each, excluding multi-system subset files that share this filename shape
@@ -48,14 +45,12 @@ def resolve_metrics(
 
 
 def coverage_problems(index: pd.Index, expected: set[str]) -> list[str]:
-    """Reasons a per-system metric index isn't exactly the expected DynaMat v1.0 set
-    (duplicate, missing or unexpected systems); an empty list means exact coverage.
-    """
+    """Return duplicate, missing, and unexpected system coverage problems."""
     present = set(index)
     problems = []
     if index.has_duplicates:
-        dups = sorted(index[index.duplicated()].unique())
-        problems.append(f"duplicate systems {dups}")
+        duplicates = sorted(index[index.duplicated()].unique())
+        problems.append(f"duplicate systems {duplicates}")
     if missing := expected - present:
         problems.append(f"{len(missing)} missing e.g. {sorted(missing)[:3]}")
     if extra := present - expected:
@@ -64,64 +59,39 @@ def coverage_problems(index: pd.Index, expected: set[str]) -> list[str]:
 
 
 def main() -> int:
-    """Evaluate MD metrics and update model YAML files.
+    """Evaluate MD metrics, returning 0 if any model succeeds and 1 otherwise."""
+    expected: set[str] | None = None
 
-    Returns:
-        Exit code: 0 if at least one model was evaluated, 1 otherwise.
-    """
-    models_to_evaluate = cli_args.models
-    print(f"Evaluating MD metrics for {len(models_to_evaluate)} model(s)...")
+    def evaluate_one(model: Model) -> str | None:
+        nonlocal expected
+        resolved = resolve_metrics(model, model.metrics.get("md") or {})
+        if resolved is None:
+            return "no per-system CSVs or md_path"
+        df_md, pred_file, pred_file_url, is_fresh_combine = resolved
 
-    n_success = 0
-    n_skipped = 0
-    expected: set[str] | None = None  # DynaMat v1.0 system set, resolved lazily once
+        # Resolve the canonical set only after finding an artifact.
+        if expected is None:
+            expected = set(list_reference_systems(default_md_reference_path()))
+        if problems := coverage_problems(df_md.index, expected):
+            return "; ".join(problems)
 
-    for model in models_to_evaluate:
-        md_yaml = model.metrics.get("md") or {}
-        try:
-            # resolve inside the try so a malformed CSV skips only this model
-            resolved = resolve_metrics(model, md_yaml)
-            if resolved is None:
-                print(f"Skipping {model.label}: no per-system CSVs or md_path")
-                n_skipped += 1
-                continue
-            df_md, pred_file, pred_file_url, is_fresh_combine = resolved
+        if is_fresh_combine:
+            out_csv = f"{ROOT}/{pred_file}"
+            os.makedirs(os.path.dirname(out_csv), exist_ok=True)
+            df_md.to_csv(out_csv)
+            print(f"\n{model.label}: combined {len(df_md)} systems")
 
-            # only persist metrics from exact DynaMat v1.0 coverage: missing systems
-            # give uneven means across models, while duplicate or unexpected (e.g.
-            # debug) rows silently skew them. Guards fresh and submitted CSVs alike.
-            if expected is None:
-                # canonical DynaMat v1.0 names (downloads reference if not cached)
-                expected = set(list_reference_systems(default_md_reference_path()))
-            if problems := coverage_problems(df_md.index, expected):
-                print(f"Skipping {model.label}: " + "; ".join(problems))
-                n_skipped += 1
-                continue
+        metrics = md_metrics.calc_md_metrics(df_md)
+        for key, value in metrics.items():
+            shown = f"{value:.4f}" if isinstance(value, float) else value
+            print(f"\t{key}={shown}")
+        md_metrics.write_metrics_to_yaml(
+            model, metrics, pred_file_path=pred_file, pred_file_url=pred_file_url
+        )
+        print(f"\tUpdated {model.yaml_path}")
+        return None
 
-            if is_fresh_combine:  # persist the freshly combined per-system metrics
-                out_csv = f"{ROOT}/{pred_file}"
-                os.makedirs(os.path.dirname(out_csv), exist_ok=True)
-                df_md.to_csv(out_csv)
-                print(f"\n{model.label}: combined {len(df_md)} systems")
-
-            metrics = md_metrics.calc_md_metrics(df_md)
-            for key, value in metrics.items():
-                shown = f"{value:.4f}" if isinstance(value, float) else value
-                print(f"\t{key}={shown}")
-            md_metrics.write_metrics_to_yaml(
-                model, metrics, pred_file_path=pred_file, pred_file_url=pred_file_url
-            )
-            print(f"\tUpdated {model.yaml_path}")
-            n_success += 1
-        except (ValueError, OSError, KeyError) as exc:
-            print(f"\tError processing {model.label}: {exc}")
-            n_skipped += 1
-
-    if n_success == 0:
-        print(f"\nNo models evaluated successfully ({n_skipped} skipped)")
-        return 1
-    print(f"\nSuccessfully evaluated {n_success} model(s), {n_skipped} skipped")
-    return 0
+    return evaluate_models("MD", cli_args.models, evaluate_one)
 
 
 if __name__ == "__main__":

--- a/scripts/make_api_docs.py
+++ b/scripts/make_api_docs.py
@@ -1,44 +1,69 @@
-"""Update auto-generated API docs viewable on the site's /api page."""
+"""Generate the site's API reference."""
 
 # /// script
 # dependencies = ["lazydocs @ git+https://github.com/ml-tooling/lazydocs"]
 # ///
 
+import annotationlib
+import dataclasses
+import functools
+import importlib
+import inspect
 import json
 import os
-from glob import glob
+import pkgutil
+import re
+import shutil
+import subprocess
+from types import SimpleNamespace
 
-from lazydocs import generate_docs
+from lazydocs.generation import MarkdownGenerator, to_md_file
 
-SITE = f"{os.path.dirname(__file__)}/../site"
+import matbench_discovery
 
-with open(f"{SITE}/package.json") as file:
-    pkg = json.load(file)  # get repo URL from package.json
+ROOT = os.path.normpath(f"{os.path.dirname(__file__)}/..")
+OUT_DIR = f"{ROOT}/site/src/routes/api/modules"
+PREFIX = f"{matbench_discovery.__name__}."
 
-out_path = f"{SITE}/src/routes/api"
 
-for path in glob(f"{out_path}/*.md"):
-    os.remove(path)
-
-generate_docs(
-    ["matbench_discovery"],
-    output_path=out_path,
-    watermark=False,
-    src_base_url=f"{pkg['repository']}/blob/-",
+inspect.signature = functools.partial(
+    inspect.signature, annotation_format=annotationlib.Format.STRING
 )
 
-# Tweak lazydocs's markdown output:
-for path in glob(f"{out_path}/*.md"):
-    with open(path) as file:
-        text = file.read()
+with open(f"{ROOT}/site/package.json") as file:
+    repo_url = json.load(file)["repository"]
+commit = subprocess.check_output(
+    ["git", "rev-parse", "HEAD"],  # noqa: S607
+    cwd=ROOT,
+    text=True,
+).strip()
 
-    # remove bold tags since they break inline code
-    text = text.replace("<b>", "").replace("</b>", "")
+shutil.rmtree(OUT_DIR, ignore_errors=True)
+os.makedirs(OUT_DIR)
+generator = MarkdownGenerator(ROOT, f"{repo_url}/blob/{commit}")
+walked_modules = pkgutil.walk_packages(matbench_discovery.__path__, PREFIX)
+modules = [matbench_discovery.__name__, *(mod.name for mod in walked_modules)]
 
-    # make badges linking to GitHub source code blue with flat style, add alt text
-    text = text.replace(
+for mod_name in modules:
+    module = importlib.import_module(mod_name)
+    for obj in vars(module).values():
+        if dataclasses.is_dataclass(obj):
+            for field in dataclasses.fields(obj):
+                field.type = SimpleNamespace(
+                    __name__=inspect.formatannotation(
+                        field.type, quote_annotation_strings=False
+                    )
+                )
+
+    md_text = generator.module2md(module).replace("<b>", "").replace("</b>", "")
+    md_text = md_text.replace(".py#L0", ".py")
+    md_text = re.sub(r" at 0x[0-9a-f]+(?=>)", "", md_text)
+    md_text = re.sub(r'<a href="[^"]*%3Cstring%3E"><img[^>]*></a>\n*', "", md_text)
+    md_text = md_text.replace(
         'src="https://img.shields.io/badge/-source-cccccc?style=flat-square"',
         'src="https://img.shields.io/badge/source-blue?style=flat" alt="source link"',
     )
-    with open(path, mode="w") as file:
-        file.write(text)
+    file_name = mod_name.removeprefix(PREFIX).replace(".", "-")
+    to_md_file(md_text, file_name, OUT_DIR, watermark=False)
+
+print(f"Wrote docs for {len(modules)} modules to {OUT_DIR}")

--- a/site/package.json
+++ b/site/package.json
@@ -42,7 +42,7 @@
     "remark-rehype": "^11.1.2",
     "svelte": "^5.56.8",
     "svelte-check-rs": "0.11.0",
-    "svelte-widgets": "^1.4.0",
+    "svelte-widgets": "github:janosh/svelte-widgets#main",
     "typescript": "6.0.3",
     "unified": "^11.0.5",
     "vite": "^8.2.0",

--- a/site/src/lib/PtableHeatmap.svelte
+++ b/site/src/lib/PtableHeatmap.svelte
@@ -50,7 +50,7 @@
       <ColorBar
         title="Count"
         title_side="top"
-        {color_scale}
+        scale={color_scale}
         tick_labels={5}
         range={[0, Math.max(0, ...(Object.values(heatmap_values) as number[]))]}
         style="width: 85%; margin: 0 2em 2em"

--- a/site/src/lib/labels.ts
+++ b/site/src/lib/labels.ts
@@ -1,6 +1,6 @@
 import type { DiscoverySet, Label, OrgLogo } from '$lib/types'
 import MODELINGS_TASKS from '$pkg/modeling-tasks.yml'
-import { LogoMeta, LogoMicrosoft } from 'svelte-widgets/icons'
+import { Meta, Microsoft } from 'svelte-widgets/icons'
 
 import type {
   DatasetMetadataLabels,
@@ -847,13 +847,13 @@ const org_logos = {
   'DAMO Academy, Alibaba Inc': `/logos/damo-academy-alibaba.svg`,
   'Deep Principle': `/logos/deep-principle.svg`,
   DeePMD: `/logos/deepmd.svg`,
-  'FAIR at Meta': LogoMeta,
+  'FAIR at Meta': Meta,
   'Google DeepMind': `/logos/google-deepmind.svg`,
   'ICAMS, Ruhr University Bochum': `/logos/interdisciplinary-centre-for-advanced-materials-simulation-bochum.svg`,
   'Incheon National University': `/logos/incheon-national-university.svg`,
   'Institute of Computing Technology, Chinese Academy of Science, Beijing': `/logos/institute-of-computing-technology-chinese-academy-of-sciences-beijing.svg`,
   'Massachusetts Institute of Technology': `/logos/massachusetts-institute-of-technology.svg`,
-  'Microsoft Research': LogoMicrosoft,
+  'Microsoft Research': Microsoft,
   'MIR Group, Harvard University': `/logos/materials-intelligence-research-group-harvard-university.svg`,
   'Mirror Physics': `/logos/mirror-physics.svg`,
   'National Institute of Standards and Technology': `/logos/national-institute-of-standards-and-technology.svg`,

--- a/site/src/lib/model/ModelAuthor.svelte
+++ b/site/src/lib/model/ModelAuthor.svelte
@@ -2,7 +2,7 @@
   import type { Author } from '$lib'
   import { get_org_logo } from '$lib/labels'
   import { Icon } from 'svelte-widgets'
-  import { Contact, GitHub, Globe, Orcid } from 'svelte-widgets/icons'
+  import { Email, GitHub, Globe, ORCID } from 'svelte-widgets/icons'
   import type { HTMLAttributes } from 'svelte/elements'
   import Logo from '../Logo.svelte'
 
@@ -19,8 +19,8 @@
     show_affiliation && affiliation ? get_org_logo(affiliation) : undefined,
   )
   let author_links = $derived([
-    [email ? `mailto:${email}` : undefined, `Email`, Contact],
-    [orcid, `Orcid`, Orcid],
+    [email ? `mailto:${email}` : undefined, `Email`, Email],
+    [orcid, `Orcid`, ORCID],
     [url, `Website`, Globe],
     [github, `GitHub`, GitHub],
   ] as const)

--- a/site/src/lib/plot/DynamicScatter.svelte
+++ b/site/src/lib/plot/DynamicScatter.svelte
@@ -2,8 +2,8 @@
   import { goto } from '$app/navigation'
   import type { ModelData } from '$lib'
   import { extent } from 'd3-array'
+  import { interpolateViridis } from 'd3-scale-chromatic'
   import { format_num, format_relative_time, ScatterPlot } from 'matterviz'
-  import { create_color_scale } from 'matterviz/plot'
   import type { DataSeries, InternalPoint } from 'matterviz/plot'
   import type { ComponentProps } from 'svelte'
   import { tick } from 'svelte'
@@ -200,11 +200,16 @@
     scheme: `interpolateViridis` as const,
     type: scale_of(`color`),
   })
-  let legend_color_scale = $derived.by(() => {
-    const [min, max] = extent(plot_data, (item) => item.color_value)
-    return create_color_scale(color_scale, [min ?? 0, max ?? 1])
-  })
-  const point_fill = (value: number) => legend_color_scale(value) ?? `gray`
+  let color_domain = $derived(extent(plot_data, (item) => item.color_value))
+  const point_fill = (value: number) => {
+    const [min = 0, max = 1] = color_domain
+    if (min === max) return interpolateViridis(0.5)
+    const fraction =
+      color_scale.type === `log`
+        ? Math.log(value / min) / Math.log(max / min)
+        : (value - min) / (max - min)
+    return interpolateViridis(fraction)
+  }
 
   // Staircase through the non-dominated models, tracing the boundary of the dominated
   // region. With a date on the x-axis it becomes the running best over time (records

--- a/site/src/lib/plot/DynamicScatter.svelte
+++ b/site/src/lib/plot/DynamicScatter.svelte
@@ -54,7 +54,6 @@
   let {
     models,
     model_filter = () => true,
-    point_color = null,
     show_model_labels = true,
     // Bindable so page headings can track user-selected axes.
     x_key = $bindable(ALL_METRICS.κ_SRME.key),
@@ -67,7 +66,6 @@
   }: ComponentProps<typeof ScatterPlot> & {
     models: ModelData[]
     model_filter?: (model: ModelData) => boolean
-    point_color?: string | null
     show_model_labels?: boolean
     x_key?: string
     y_key?: string
@@ -148,7 +146,7 @@
         !is_finite_num(x) ||
         !is_finite_num(y) ||
         !is_finite_num(size_value) ||
-        (point_color === null && !is_finite_num(color_value))
+        !is_finite_num(color_value)
       ) {
         return []
       }
@@ -171,7 +169,7 @@
     prop: Label | undefined,
     value_key: `x` | `y` | `color_value` | `size_value`,
   ): boolean => {
-    const [min, max] = extent(plot_data, (point) => point[value_key] as number)
+    const [min, max] = extent(plot_data, (point) => point[value_key])
     return (
       !label_data_path(prop).includes(`date`) &&
       min !== undefined &&
@@ -203,11 +201,10 @@
     type: scale_of(`color`),
   })
   let legend_color_scale = $derived.by(() => {
-    const [min, max] = extent(plot_data, (item) => item.color_value as number)
+    const [min, max] = extent(plot_data, (item) => item.color_value)
     return create_color_scale(color_scale, [min ?? 0, max ?? 1])
   })
-  const point_fill = (color_value: unknown): string =>
-    point_color ?? (legend_color_scale(color_value as number) as string) ?? `gray`
+  const point_fill = (value: number) => legend_color_scale(value) ?? `gray`
 
   // Staircase through the non-dominated models, tracing the boundary of the dominated
   // region. With a date on the x-axis it becomes the running best over time (records
@@ -260,7 +257,7 @@
       // uniform circles: color and size already encode data, and cycling 7 shapes
       // across 30+ models distinguished nothing while adding visual noise
       point_style: { fill: point_fill(item.color_value), symbol_type: `Circle` as const },
-      color_values: point_color === null ? [item.color_value as number] : undefined,
+      color_values: [item.color_value],
       size_values: axes.size_value ? [item.size_value] : undefined,
       point_label: show_model_labels
         ? [

--- a/site/src/lib/plot/EnergyParityPlot.svelte
+++ b/site/src/lib/plot/EnergyParityPlot.svelte
@@ -333,8 +333,8 @@ title, so label the section for screen readers instead -->
       y_axis={{ label: y_label, format: `.2f`, range: extent }}
       density={{
         color_scale: { type: `log`, scheme: `interpolateMagma` },
-        color_bar: { title: `Density`, class: colorbar_class },
       }}
+      color_bar={{ title: `Density`, class: colorbar_class }}
       size_scale={{ radius_range: [2, 18], pick_radius: `auto` }}
       overlays={parity_overlays}
       on_point_click={({ point }) => void show_structure(Number(point.point_id))}

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
     Toc,
   } from 'svelte-widgets'
   import type { FooterLink } from 'svelte-widgets'
-  import { Changelog, Contact, Issues, RSS, Search } from 'svelte-widgets/icons'
+  import { Changelog, Email, Issues, RSS, Search } from 'svelte-widgets/icons'
   import MODELING_TASKS from '$pkg/modeling-tasks.yml'
   import pkg from '$site/package.json'
   import { tick, type Snippet } from 'svelte'
@@ -33,7 +33,7 @@
     {
       href: `mailto:janosh.riebesell@gmail.com?subject=Matbench Discovery`,
       label: `Contact`,
-      icon: Contact,
+      icon: Email,
     },
     { href: `/changelog`, label: `Changelog`, icon: Changelog },
     {

--- a/site/src/routes/api/+page.svelte
+++ b/site/src/routes/api/+page.svelte
@@ -1,15 +1,20 @@
 <script lang="ts">
   import type { Component } from 'svelte'
+  import Intro from './intro.md'
 
-  const modules = import.meta.glob<Component>(`./*.md`, {
-    eager: true,
-    import: 'default',
-  })
+  const modules = Object.entries(
+    import.meta.glob<Component>(`./modules/*.md`, {
+      eager: true,
+      import: 'default',
+    }),
+  ).toSorted(([path_a], [path_b]) => path_a.localeCompare(path_b))
 </script>
 
 <h1 class="toc-exclude">API</h1>
 
-{#each Object.entries(modules) as [path, MdFile] (path)}
+<Intro />
+
+{#each modules as [path, MdFile] (path)}
   <MdFile />
 {/each}
 

--- a/site/src/routes/api/intro.md
+++ b/site/src/routes/api/intro.md
@@ -1,0 +1,39 @@
+The [`matbench-discovery`](https://pypi.org/project/matbench-discovery) Python package is the reference implementation behind this benchmark. It fetches the training and test sets, provides the shared task runners that every model submission plugs into, and computes each metric shown on the leaderboards.
+
+```sh
+pip install matbench-discovery
+```
+
+## Quickstart
+
+Load the WBM test set alongside a model's predictions and reproduce its discovery metrics:
+
+```python
+from matbench_discovery.data import load_df_wbm_with_preds
+from matbench_discovery.enums import MbdKey, Model
+from matbench_discovery.metrics.discovery import stable_metrics
+
+model = Model.mace_mp_0
+
+# downloads (and caches) the WBM test set plus this model's predictions
+df_wbm = load_df_wbm_with_preds(models=[model])
+
+# predicted hull distance = DFT hull distance + the model's formation energy error
+each_pred = df_wbm[MbdKey.each_true] + df_wbm[model.label] - df_wbm[MbdKey.e_form_dft]
+
+print(stable_metrics(df_wbm[MbdKey.each_true], each_pred))
+# {'F1': 0.665, 'DAF': 3.457, 'Precision': 0.576, 'Recall': 0.787, ...}
+```
+
+Downloads are cached in `data/` if you cloned the repo and under `~/.cache/matbench-discovery` otherwise. Set `MBD_CACHE_DIR` to override.
+
+## Where to look
+
+- **Registries and data** — `enums` holds the `Model` and `DataFiles` registries plus the column-name enums (`MbdKey`, `Task`, `TestSubset`), and `data` loads them into dataframes.
+- **Metrics** — `metrics.discovery`, `metrics.geo_opt`, `metrics.phonons`, `metrics.md` and `metrics.diatomics` compute the leaderboard numbers for each task.
+- **Task runners** — `discovery`, `phonons`, `md` and `diatomics` drive the evaluations, `calculators` builds each model's ASE calculator, and `ase_relax` performs the relaxations.
+- **Supporting modules** — `figs` and `data_figs` build this site's plots, `remote` handles downloads and Figshare uploads, and `hpc`, `cli` and `runner_cli` back the Slurm submission scripts.
+
+Contributing a model means registering a calculator rather than calling these modules yourself — see [the contribution guide](/contribute).
+
+Everything below is generated from the package's docstrings, and each `source` badge links to the exact commit this site was built from.

--- a/site/src/routes/data/[slug]/+page.svelte
+++ b/site/src/routes/data/[slug]/+page.svelte
@@ -6,16 +6,16 @@
     Calendar,
     CalendarPlus,
     Code,
-    Contact,
     DOI,
     Database,
     Download,
+    Email,
     GitHub,
     Globe,
     Lattice,
     License,
     Lock,
-    Orcid,
+    ORCID,
     Unlock,
   } from 'svelte-widgets/icons'
   import pkg from '$site/package.json'
@@ -174,7 +174,7 @@
           {/if}
           {#if person.email}
             <a href="mailto:{person.email}" aria-label="Email">
-              <Icon icon={Contact} />
+              <Icon icon={Email} />
             </a>
           {/if}
           {#if person.github}
@@ -184,7 +184,7 @@
           {/if}
           {#if person.orcid}
             <a href={person.orcid} {...link_props} aria-label="ORCID">
-              <Icon icon={Orcid} />
+              <Icon icon={ORCID} />
             </a>{/if}
           {#if person.url}
             <a href={person.url} {...link_props} aria-label="Website">

--- a/site/src/routes/models/+page.svelte
+++ b/site/src/routes/models/+page.svelte
@@ -158,7 +158,7 @@ track, which would miscenter it and overflow at wider browser zoom levels. -->
     {#each models.slice(0, Math.max(min_models, show_n_best)) as model (model.model_name)}
       {@const metric_val = sort_by.better ? get_nested_value(model, sort_by_path) : 0}
       {@const bg_clr = bg_color(metric_val as number, best_val, worst_val)}
-      {@const text_color = pick_contrast_color({ background: bg_clr })}
+      {@const text_color = pick_contrast_color({ background: bg_clr, backdrop: `white` })}
       <li
         animate:flip={{ duration: 400 }}
         in:fade={{ delay: 100 }}

--- a/site/src/routes/models/+page.svelte
+++ b/site/src/routes/models/+page.svelte
@@ -141,7 +141,10 @@ track, which would miscenter it and overflow at wider browser zoom levels. -->
     <ColorBar
       title="Card titles colored by {sort_by.label}"
       title_style="font-size: 1.5em;"
-      color_scale={lower_is_better ? (t) => interpolateRdBu(1 - t) : interpolateRdBu}
+      scale={{
+        interpolator: (fraction) =>
+          interpolateRdBu(lower_is_better ? 1 - fraction : fraction),
+      }}
       style="min-width: min(70vw, 400px)"
       bar_style="height: 14pt;"
       range={lower_is_better ? [worst_val, best_val] : [best_val, worst_val]}
@@ -155,7 +158,7 @@ track, which would miscenter it and overflow at wider browser zoom levels. -->
     {#each models.slice(0, Math.max(min_models, show_n_best)) as model (model.model_name)}
       {@const metric_val = sort_by.better ? get_nested_value(model, sort_by_path) : 0}
       {@const bg_clr = bg_color(metric_val as number, best_val, worst_val)}
-      {@const text_color = pick_contrast_color({ bg_color: bg_clr })}
+      {@const text_color = pick_contrast_color({ background: bg_clr })}
       <li
         animate:flip={{ duration: 400 }}
         in:fade={{ delay: 100 }}

--- a/site/src/routes/models/[slug]/+page.svelte
+++ b/site/src/routes/models/[slug]/+page.svelte
@@ -319,7 +319,7 @@
             <ColorBar
               title="|E<sub>ML,hull</sub> - E<sub>DFT,hull</sub>| (eV / atom)"
               title_side="top"
-              {color_scale}
+              scale={color_scale}
               range={[0, Math.max(0, ...Object.values(heatmap_values))]}
               style="width: 80%; margin: 0 2em"
             />

--- a/site/src/routes/tasks/diatomics/+page.svelte
+++ b/site/src/routes/tasks/diatomics/+page.svelte
@@ -101,7 +101,7 @@
   let selectable_options = $derived(
     selectable_names.map((model_name) => {
       const model_color = color_for(model_name)
-      const text_color = pick_contrast_color({ bg_color: model_color })
+      const text_color = pick_contrast_color({ background: model_color })
       return {
         label: `${model_name}${reference_names.includes(model_name) ? ` (DFT)` : ``}`,
         value: model_name,

--- a/site/src/routes/tasks/discovery/tmi/+page.svelte
+++ b/site/src/routes/tasks/discovery/tmi/+page.svelte
@@ -169,7 +169,8 @@ plotting against that the absolute E<sub>above hull</sub> errors for each model.
   ]}
   x_axis={{ label: fp_diff_label }}
   y_axis={{ label: `|E<sub>above hull</sub> error| (eV/atom)` }}
-  density={{ color_scale: { type: `log`, scheme: `interpolateMagma` }, color_bar: null }}
+  density={{ color_scale: { type: `log`, scheme: `interpolateMagma` } }}
+  color_bar={null}
   overlays={{
     ref_lines: [
       {

--- a/site/src/routes/tasks/discovery/tmi/ElementErrorsPtableHeatmap.svelte
+++ b/site/src/routes/tasks/discovery/tmi/ElementErrorsPtableHeatmap.svelte
@@ -182,7 +182,9 @@
         <ColorBar
           title={cbar_title}
           title_side="top"
-          {color_scale}
+          scale={typeof color_scale === `string`
+            ? color_scale
+            : { interpolator: color_scale }}
           tick_labels={5}
           range={cs_range}
           style="width: 85%; margin: 0 2em"

--- a/site/src/routes/tasks/geo-opt/+page.svelte
+++ b/site/src/routes/tasks/geo-opt/+page.svelte
@@ -66,7 +66,7 @@
     .toSorted(([key_1], [key_2]) => benchmark_added_ms(key_2) - benchmark_added_ms(key_1))
     .map(([key, label]) => {
       const model_color = model_by_key.get(key)?.color ?? `gray`
-      const text_color = pick_contrast_color({ bg_color: model_color })
+      const text_color = pick_contrast_color({ background: model_color })
       return {
         label,
         value: key,

--- a/site/tests/lib/MetricsTable.test.svelte.ts
+++ b/site/tests/lib/MetricsTable.test.svelte.ts
@@ -126,25 +126,29 @@ describe(`MetricsTable`, () => {
     expect(dropdown).toBeNull()
   })
 
-  it(`renders Org as a regular rightmost metadata column`, async () => {
-    mount(MetricsTable, {
-      target: document.body,
-      props: { col_filter: () => true },
-    })
-    await tick()
+  it(
+    `renders Org as a regular rightmost metadata column`,
+    { timeout: 30_000 },
+    async () => {
+      mount(MetricsTable, {
+        target: document.body,
+        props: { col_filter: () => true },
+      })
+      await tick()
 
-    const org_cell = doc_query(`td[data-col="Org"]`)
-    const org_preview = doc_query(`td[data-col="Org"] .org-preview`)
-    const headers = header_cells()
-    const org_header = headers.at(-1)
-    if (!org_header) throw new Error(`Org column header not found`)
+      const org_cell = doc_query(`td[data-col="Org"]`)
+      const org_preview = doc_query(`td[data-col="Org"] .org-preview`)
+      const headers = header_cells()
+      const org_header = headers.at(-1)
+      if (!org_header) throw new Error(`Org column header not found`)
 
-    expect(org_header?.textContent?.trim()).toBe(`Org`)
-    expect(org_header.getAttribute(`title`)).toBeNull()
-    expect(org_header.querySelector(`.header-label`)).not.toBeNull()
-    expect(org_preview.classList.contains(`org-preview`)).toBe(true)
-    expect(org_cell.getAttribute(`style`)).not.toContain(`min-width:`)
-  })
+      expect(org_header?.textContent?.trim()).toBe(`Org`)
+      expect(org_header.getAttribute(`title`)).toBeNull()
+      expect(org_header.querySelector(`.header-label`)).not.toBeNull()
+      expect(org_preview.classList.contains(`org-preview`)).toBe(true)
+      expect(org_cell.getAttribute(`style`)).not.toContain(`min-width:`)
+    },
+  )
 
   it(`renders header tooltips on inner labels`, async () => {
     mount(MetricsTable, {
@@ -347,7 +351,7 @@ describe(`MetricsTable`, () => {
 
     const model_cell = doc_query(`td[data-col="Model"]`)
     const marker = model_cell.querySelector(
-      `span[data-original-title="Diatomics metrics exclude He-He due to exploding errors"]`,
+      `span[title="Diatomics metrics exclude He-He due to exploding errors"]`,
     )
     expect(model_cell.textContent).toContain(`AlphaNet-v1-OAM`)
     expect(marker?.textContent).toBe(`*`)
@@ -451,13 +455,13 @@ describe(`MetricsTable`, () => {
 
       // Verify tooltips are preserved on spans within cells
       const cells_with_tooltips = training_set_cells.filter(
-        (cell) => cell.querySelector(`span[data-original-title]`) !== null,
+        (cell) => cell.querySelector(`span[title]`) !== null,
       )
 
       expect(cells_with_tooltips.length).toBeGreaterThan(0)
       cells_with_tooltips.forEach((cell) => {
-        const span = cell.querySelector(`span[data-original-title]`)
-        expect(span?.getAttribute(`data-original-title`)).not.toBeNull()
+        const span = cell.querySelector(`span[title]`)
+        expect(span?.getAttribute(`title`)).not.toBeNull()
       })
     })
 
@@ -595,7 +599,7 @@ describe(`MetricsTable`, () => {
           expect(link.getAttribute(`target`)).toBe(`_blank`)
           expect(link.getAttribute(`rel`)).toBe(`noopener noreferrer`)
 
-          const title = link.getAttribute(`data-original-title`)
+          const title = link.getAttribute(`title`)
           const href = link.getAttribute(`href`)
           expect(title).not.toBeNull()
           expect(title).not.toBe(``)
@@ -626,8 +630,8 @@ describe(`MetricsTable`, () => {
       const links_cells = [...document.querySelectorAll(`td[data-col="Links"]`)]
 
       const missing_icon_titles = links_cells.flatMap((cell) =>
-        [...cell.querySelectorAll(`span[data-original-title$="not available"] svg`)].map(
-          (icon) => icon.closest(`span`)?.getAttribute(`data-original-title`),
+        [...cell.querySelectorAll(`span[title$="not available"] svg`)].map((icon) =>
+          icon.closest(`span`)?.getAttribute(`title`),
         ),
       )
 

--- a/site/tests/lib/OrgLogos.test.svelte.ts
+++ b/site/tests/lib/OrgLogos.test.svelte.ts
@@ -1,8 +1,8 @@
 import type { OrgLogo } from '$lib'
-import { LogoMeta, Magnetic } from 'svelte-widgets/icons'
+import { Magnetic, Meta } from 'svelte-widgets/icons'
 import OrgLogos from '$lib/model/OrgLogos.svelte'
 import { flushSync, type ComponentProps } from 'svelte'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { doc_query, mount } from '../index'
 
 describe(`OrgLogos.svelte`, () => {
@@ -17,13 +17,12 @@ describe(`OrgLogos.svelte`, () => {
   ): Promise<HTMLElement> => {
     mount(OrgLogos, { target: document.body, props })
     flushSync() // ensure the tooltip attachment effect has run before hovering
-    doc_query(`.org-preview`).dispatchEvent(new MouseEvent(`mouseenter`))
-    await new Promise((resolve) => setTimeout(resolve, 200))
-    return doc_query(`.custom-tooltip .tooltip-content`)
+    doc_query(`.org-preview`).dispatchEvent(new PointerEvent(`pointerover`))
+    return vi.waitFor(() => doc_query(`.custom-tooltip .tooltip-content`))
   }
 
   it(`renders one preview logo per org (src + icon types)`, () => {
-    const org_logos: OrgLogo[] = [mit_logo, { name: `FAIR at Meta`, icon: LogoMeta }]
+    const org_logos: OrgLogo[] = [mit_logo, { name: `FAIR at Meta`, icon: Meta }]
     mount(OrgLogos, { target: document.body, props: { org_logos } })
 
     expect(document.querySelectorAll(`.org-preview .org-logo`)).toHaveLength(2)
@@ -43,7 +42,7 @@ describe(`OrgLogos.svelte`, () => {
 
   it(`shows grouped authors with escaped affiliations on hover`, async () => {
     const { innerHTML } = await open_tooltip({
-      org_logos: [mit_logo, { name: `FAIR at Meta`, icon: LogoMeta }],
+      org_logos: [mit_logo, { name: `FAIR at Meta`, icon: Meta }],
       authors: [
         { name: `Ada Lovelace`, affiliation: `Massachusetts Institute of Technology` },
         { name: `Alan Turing`, affiliation: `Massachusetts Institute of Technology` },

--- a/site/tests/lib/labels.test.ts
+++ b/site/tests/lib/labels.test.ts
@@ -4,7 +4,7 @@ import {
   format_property_path,
   get_org_logo,
 } from '$lib/labels'
-import { LogoMeta, LogoMicrosoft } from 'svelte-widgets/icons'
+import { Meta, Microsoft } from 'svelte-widgets/icons'
 import { describe, expect, it } from 'vitest'
 
 describe(`format_power_ten`, () => {
@@ -132,10 +132,10 @@ describe(`get_org_logo`, () => {
 
   it.each([
     [`Google DeepMind`, src_logo(`Google DeepMind`, `/logos/google-deepmind.svg`)],
-    [`FAIR at Meta`, { name: `FAIR at Meta`, icon: LogoMeta }],
+    [`FAIR at Meta`, { name: `FAIR at Meta`, icon: Meta }],
     [
       `Microsoft Research AI for Science`,
-      { name: `Microsoft Research`, icon: LogoMicrosoft },
+      { name: `Microsoft Research`, icon: Microsoft },
     ],
     [`Some unknown university`, undefined],
     [

--- a/site/tests/routes/GeoOptPage.test.ts
+++ b/site/tests/routes/GeoOptPage.test.ts
@@ -71,12 +71,16 @@ describe(`Geo Opt Task Page`, () => {
     expect(sankey_labels()).toStrictEqual([label])
   })
 
-  it(`keeps empty states for unselected aggregate diagnostics`, async () => {
-    await mount_with_url(GeoOptPage, `http://localhost/tasks/geo-opt?models=`)
+  it(
+    `keeps empty states for unselected aggregate diagnostics`,
+    { timeout: 30_000 },
+    async () => {
+      await mount_with_url(GeoOptPage, `http://localhost/tasks/geo-opt?models=`)
 
-    expect(document.querySelectorAll(`.empty-note`)).toHaveLength(3)
-    expect(document.querySelector(`.rmsd-cdf`)).toBeNull()
-  })
+      expect(document.querySelectorAll(`.empty-note`)).toHaveLength(3)
+      expect(document.querySelector(`.rmsd-cdf`)).toBeNull()
+    },
+  )
 
   it(`restores scatter, sort, and metrics-table filters from URL params`, async () => {
     await mount_with_url(

--- a/site/tests/routes/LandingPage.test.ts
+++ b/site/tests/routes/LandingPage.test.ts
@@ -81,14 +81,14 @@ describe(`Landing Page`, () => {
     [`MD`, `Molecular Dynamics`],
   ])(`expands %s in its tooltip`, async (label, expanded_label) => {
     const button = preset_button(label)
-    button.dispatchEvent(new MouseEvent(`mouseenter`))
-    await new Promise((resolve) => setTimeout(resolve, 110))
-
-    const tooltip_id = button.getAttribute(`aria-describedby`)
-    expect(tooltip_id).not.toBeNull()
-    expect(document.querySelector(`[id="${tooltip_id}"]`)?.textContent).toContain(
-      expanded_label,
-    )
+    button.dispatchEvent(new PointerEvent(`pointerover`))
+    await vi.waitFor(() => {
+      const tooltip_id = button.getAttribute(`aria-describedby`)
+      expect(tooltip_id).not.toBeNull()
+      expect(document.querySelector(`[id="${tooltip_id}"]`)?.textContent).toContain(
+        expanded_label,
+      )
+    })
   })
 
   // Each non-default task preset reveals one of its signature columns.

--- a/site/tests/routes/LandingPage.test.ts
+++ b/site/tests/routes/LandingPage.test.ts
@@ -1,6 +1,6 @@
 import { OPENNESS_OPTIONS } from '$lib/url-state.svelte'
 import Page from '$routes/+page.svelte'
-import { tick } from 'svelte'
+import { flushSync, tick } from 'svelte'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { doc_query, mount, mount_with_url, sorted_header } from '../index'
 
@@ -81,6 +81,7 @@ describe(`Landing Page`, () => {
     [`MD`, `Molecular Dynamics`],
   ])(`expands %s in its tooltip`, async (label, expanded_label) => {
     const button = preset_button(label)
+    flushSync()
     button.dispatchEvent(new PointerEvent(`pointerover`))
     await vi.waitFor(() => {
       const tooltip_id = button.getAttribute(`aria-describedby`)

--- a/tests/discovery/test_discovery.py
+++ b/tests/discovery/test_discovery.py
@@ -21,6 +21,7 @@ from pymatviz.enums import Key
 
 import matbench_discovery.discovery as discovery_core
 import models.run_discovery as discovery_runner
+from matbench_discovery import ROOT
 from matbench_discovery.calculators import CALCULATORS
 from matbench_discovery.data import file_ref_name, file_ref_url, make_file_ref
 from matbench_discovery.discovery import (
@@ -37,7 +38,11 @@ from matbench_discovery.discovery import (
 )
 from matbench_discovery.energy import calc_energy_from_e_refs
 from matbench_discovery.enums import MbdKey, Model, TestSubset
-from matbench_discovery.hpc import partition_material_ids
+from matbench_discovery.hpc import (
+    effective_shard_args,
+    partition_material_ids,
+    slurm_shard_selection,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -181,29 +186,16 @@ def test_artifacts_match_legacy_mp2020_join_semantics(
     assert int(geo["n_steps"]) == 4
 
 
-def test_runner_normalizes_artifact_paths(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Artifact paths use POSIX repo-relative identity where possible."""
+def test_runner_normalizes_artifact_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Normalize in-repo, relative, and external artifact paths."""
     rel_path = "models/mace/mace-mp-0/2026-07-02-discovery.csv.gz"
     normalize = discovery_runner._repo_relative_path  # noqa: SLF001
-    # The YAML integration test below pins stale URL replacement.
-    assert normalize(f"{discovery_runner.ROOT}/{rel_path}") == rel_path
+    assert normalize(f"{ROOT}/{rel_path}") == rel_path
+    monkeypatch.chdir(ROOT)
+    assert normalize(rel_path) == rel_path
 
-    def windows_relpath(_path: str, _start: str) -> str:
-        """Return a Windows-style relative artifact path."""
-        return rel_path.replace("/", "\\")
-
-    monkeypatch.setattr(discovery_runner.os.path, "relpath", windows_relpath)
-    assert normalize(f"{discovery_runner.ROOT}/{rel_path}") == rel_path
-
-    def raise_cross_drive(_path: str, _start: str) -> str:
-        """Mimic relpath failing across Windows drives."""
-        raise ValueError("path is on mount 'C:', start on mount 'D:'")
-
-    monkeypatch.setattr(discovery_runner.os.path, "relpath", raise_cross_drive)
-    external_path = "/mnt/c/tmp/preds.csv.gz"
-    assert normalize(external_path) == os.path.abspath(external_path)
+    for external_path in ("/mnt/c/tmp/preds.csv.gz", f"{ROOT}/../outside.csv.gz"):
+        assert normalize(external_path) == os.path.abspath(external_path)
 
 
 def test_write_yaml_results_masks_outliers_and_updates_yaml(
@@ -545,9 +537,7 @@ def test_implicit_slurm_dry_run_uses_only_first_task(
     monkeypatch.setenv("SLURM_ARRAY_TASK_COUNT", "20")
     monkeypatch.setenv("SLURM_ARRAY_TASK_MIN", "5")
     monkeypatch.setenv("SLURM_ARRAY_TASK_ID", str(task_id))
-    assert discovery_runner._effective_shard_args(  # noqa: SLF001
-        None, None, dry_run=True
-    ) == (1, 0, should_skip)
+    assert effective_shard_args(None, None, dry_run=True) == (1, 0, should_skip)
 
 
 @pytest.mark.parametrize(
@@ -576,14 +566,9 @@ def test_slurm_shard_selection(
     monkeypatch.setenv("SLURM_ARRAY_TASK_ID", str(task_id))
     if isinstance(expected, str):
         with pytest.raises(ValueError, match=expected):
-            discovery_runner._slurm_shard_selection(n_shards, None)  # noqa: SLF001
+            slurm_shard_selection(n_shards, None)
     else:
-        assert (
-            discovery_runner._slurm_shard_selection(  # noqa: SLF001
-                n_shards, None
-            )
-            == expected
-        )
+        assert slurm_shard_selection(n_shards, None) == expected
 
 
 def test_shard_resume_preserves_success_and_failure_records(tmp_path: Path) -> None:

--- a/tests/metrics/test_md_metrics.py
+++ b/tests/metrics/test_md_metrics.py
@@ -206,12 +206,21 @@ def test_calc_rdf_error(
     err = md_metrics.calc_rdf_error(radii, np.array(g_r_ref), np.array(g_r_pred))
     assert err == pytest.approx(expected)
 
-    with pytest.raises(ValueError, match="differ"):  # mismatched grid lengths
-        md_metrics.calc_rdf_error(radii, np.ones(3), np.ones(4))
-    with pytest.raises(ValueError, match="negative"):
-        md_metrics.calc_rdf_error(radii, np.array([0.0, -1.0, 1.0]), np.ones(3))
-    with pytest.raises(ValueError, match="non-finite"):
-        md_metrics.calc_rdf_error(radii, np.array([0.0, np.inf, 1.0]), np.ones(3))
+
+@pytest.mark.parametrize(
+    ("g_r_ref", "g_r_pred", "err_msg"),
+    [
+        (np.ones(3), np.ones(4), "differ"),  # mismatched grid lengths
+        (np.array([0.0, -1.0, 1.0]), np.ones(3), "negative"),
+        (np.array([0.0, np.inf, 1.0]), np.ones(3), "non-finite"),
+    ],
+)
+def test_calc_rdf_error_invalid_input(
+    g_r_ref: np.ndarray, g_r_pred: np.ndarray, err_msg: str
+) -> None:
+    """RDF error should reject mismatched, negative and non-finite distributions."""
+    with pytest.raises(ValueError, match=err_msg):
+        md_metrics.calc_rdf_error(np.array([1.0, 2.0, 3.0]), g_r_ref, g_r_pred)
 
 
 # === ADF ===
@@ -765,9 +774,18 @@ def test_matched_frame_counts(
     )
     assert result == expected
 
-    with pytest.raises(ValueError, match="must be positive"):  # zero time step
+
+@pytest.mark.parametrize(("ref_dt", "pred_dt"), [(0, 1), (1, 0)])
+def test_matched_frame_counts_rejects_zero_time_step(
+    ref_dt: float, pred_dt: float
+) -> None:
+    """A zero time step has no common grid, so it must raise rather than divide by 0."""
+    with pytest.raises(ValueError, match="must be positive"):
         md_metrics.matched_frame_counts(
-            n_ref_frames=5, n_pred_frames=5, ref_time_step_fs=0, pred_time_step_fs=1
+            n_ref_frames=5,
+            n_pred_frames=5,
+            ref_time_step_fs=ref_dt,
+            pred_time_step_fs=pred_dt,
         )
 
 

--- a/tests/phonons/test_kappa_pipeline.py
+++ b/tests/phonons/test_kappa_pipeline.py
@@ -18,12 +18,12 @@ from pymatviz.enums import Key
 from matbench_discovery.enums import MbdKey, Model
 from matbench_discovery.phonons.adapters import (
     FairchemKappaAdapter,
-    RelaxationResult,
     StandardKappaAdapter,
     get_kappa_adapter,
 )
 from matbench_discovery.phonons.adapters.equflash import EquFlashKappaAdapter
 from matbench_discovery.phonons.adapters.pet import PetKappaAdapter
+from matbench_discovery.phonons.adapters.standard import RelaxationResult
 from matbench_discovery.phonons.pipeline import (
     DRY_RUN_MAX_FC3_EVALUATIONS,
     KAPPA_PROTOCOL,

--- a/tests/scripts/test_evals.py
+++ b/tests/scripts/test_evals.py
@@ -1,0 +1,49 @@
+"""Tests for the per-model sweep shared by scripts/evals."""
+
+import pytest
+
+from matbench_discovery.enums import Model
+from scripts.evals import evaluate_models
+
+MODEL_A, MODEL_B = Model.mace_mp_0, Model.chgnet_0_3_0
+Outcome = str | Exception | None  # skip reason, raised error, or success
+
+
+@pytest.mark.parametrize(
+    ("models", "outcomes", "expected_code"),
+    [
+        ([], {}, 0),  # selecting nothing is not a failure
+        ([MODEL_A], {MODEL_A: None}, 0),
+        ([MODEL_A], {MODEL_A: "no artifact"}, 1),
+        ([MODEL_A], {MODEL_A: ValueError("boom")}, 1),
+        ([MODEL_A, MODEL_B], {MODEL_A: None, MODEL_B: "no artifact"}, 0),
+        ([MODEL_A, MODEL_B], {MODEL_A: None, MODEL_B: OSError("boom")}, 1),
+    ],
+    ids=["empty", "ok", "all-skipped", "all-failed", "partial-skip", "partial-fail"],
+)
+def test_evaluate_models_exit_code(
+    models: list[Model], outcomes: dict[Model, Outcome], expected_code: int
+) -> None:
+    """Errors fail the sweep even alongside successes; skips and empty runs don't."""
+
+    def evaluate_one(model: Model) -> str | None:
+        outcome = outcomes[model]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    assert evaluate_models("test", models, evaluate_one) == expected_code
+
+
+def test_evaluate_models_counts_errors_apart_from_skips(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The summary must not report an errored model as skipped."""
+
+    def evaluate_one(model: Model) -> str | None:
+        if model is MODEL_B:
+            raise KeyError("boom")
+        return "no artifact"
+
+    assert evaluate_models("test", [MODEL_A, MODEL_B], evaluate_one) == 1
+    assert "1 skipped, 1 failed" in capsys.readouterr().out

--- a/tests/scripts/test_evals.py
+++ b/tests/scripts/test_evals.py
@@ -24,7 +24,7 @@ Outcome = str | Exception | None  # skip reason, raised error, or success
 def test_evaluate_models_exit_code(
     models: list[Model], outcomes: dict[Model, Outcome], expected_code: int
 ) -> None:
-    """Errors fail the sweep even alongside successes; skips and empty runs don't."""
+    """Errors fail; all-skipped non-empty runs return 1, while empty runs return 0."""
 
     def evaluate_one(model: Model) -> str | None:
         outcome = outcomes[model]


### PR DESCRIPTION
Consolidates duplicated scaffolding across the task runners, eval scripts and metrics modules, and fixes the API page silently omitting a third of the package.

## API docs

`lazydocs.generate_docs()` catches per-module errors and still exits 0, so 10 of 33 modules never reached the site — including `discovery.py`, which runs the flagship task. Driving `MarkdownGenerator` directly with `Format.STRING` annotations sidesteps the PEP 649 `NameError`s raised by `if TYPE_CHECKING` imports, and dataclass fields now render their full annotation rather than a bare `Union`.

Also in this area:

- Output files are keyed by dashes, so module `metrics.md` no longer clobbers package `metrics`
- Source badges pin to the built commit instead of `/blob/-`, which 302-redirected to whatever `main` happened to be
- Broken `<string>` and `#L0` badges are dropped, and memory addresses are stripped so builds are reproducible
- `structure/` and `remote/` gain `__init__.py`, so `pkgutil` walks their four modules
- The page opens with a hand-written intro covering install, a quickstart and an orientation of the module groups

Coverage goes from 22 to 40 modules.

## Shared scaffolding

- `runner_cli` gains `add_common_runner_args` and `add_shard_args`, so the four task runners stop redeclaring the same model-selection, dependency-isolation and shard flags. Shard resolution moves onto `hpc.effective_shard_args` / `slurm_shard_selection`.
- `scripts/evals` gains `evaluate_models`, so `md`, `kappa`, `diatomic_metrics` and `discovery` agree on tolerated exceptions, tallies and exit codes. Evaluators signal an expected gap by returning a reason string. `discovery.py` previously swallowed every error and always exited 0, so the CI `scripts` job stayed green even when nothing was written.
- `file_sha256` had three near-identical copies and every metrics module hand-rolled the same `CommentedMap` + `yaml_add_eol_comment` loop. Both now live in `data.py`.

## Housekeeping

Pre-commit hook version bumps, and `test.yml` no longer triggers on `release` since `release.yml` already calls it via `workflow_call`, which ran the full suite twice per release. Plus the remaining `svelte-widgets` 1.4 prop renames.

## Known follow-up

Patching `inspect.signature` with `Format.STRING` globally leaves parameter annotations quoted, e.g. `each_true: 'Sequence[float | None] | pd.Series | np.ndarray'` (724 occurrences). The annotation text itself is the source form rather than fully-qualified, which reads better; only the surrounding quotes are wrong. Return types are unaffected.