### PR TITLE
Add ELEMENTA dataset

### DIFF
--- a/data/datasets.yml
+++ b/data/datasets.yml
@@ -700,3 +700,42 @@ MDR-MP PBE ω_q:
     Potentials". This dataset was constructed by randomly sampling 8,510
     structures with overlapping mp-id's with MPtrj and preprocessing into
     .aselmbd files with the Hessian stored in atoms.info["hessian"].
+
+ELEMENTA:
+  name: ELEMENTA
+  url: https://www.kairosmaterials.com/papers/ELEMENTA.pdf
+  download_url: https://huggingface.co/datasets/kairosmaterial/ELEMENTA
+  doi: https://doi.org/10.5281/zenodo.22638068
+  n_structures: 210656285
+  n_materials: 9781175
+  open: false
+  static: true
+  optimade_api: null
+  native_api: null
+  date_created: 2026-07-27
+  license: CC-BY-NC-4.0
+  description: |
+    Composition-complete, prototype-independent first-principles dataset by Kairos Materials.
+    Systematically enumerates unary, binary and ternary compositions with up to twelve atoms
+    per cell (~1.9M reduced formulas) explored via random structure search, represented by DFT
+    relaxation trajectories: ~210 million frames with energies, forces and stresses over >9.7M
+    distinct relaxed polymorphs. As for the training of the models for Matbench Discovery, structures
+    overlapping with the WBM benchmark test set were removed during post processing. Two expansion
+    sets probe additional physical dimensions:ELEMENTA Spin (4.7M frames, systematic magnetic-moment scans)
+    and ELEMENTA Vib (~8M perturbed structures probing local vibrational environments and energy-surface curvature).
+  notes:
+    Availability: |
+      The full 210M-frame corpus is not public. A first public release is available on
+      [Hugging Face](https://huggingface.co/datasets/kairosmaterial/ELEMENTA) under
+      CC-BY-NC-4.0: ~39M core frames (complete unary and binary chemical spaces plus
+      ternary compositions with reduced-formula stoichiometric coefficients) togetherss
+      with the complete 4.7M-frame ELEMENTA Spin set, in extended-XYZ format.
+  method: DFT
+  params:
+    code: VASP
+    functional: PBE+U
+    pseudopotentials: PBE
+  created_by:
+    - name: Kairos Materials Team
+      email: research@kairosmaterials.com
+      url: https://www.kairosmaterials.com


### PR DESCRIPTION
Registers the **ELEMENTA** dataset (Kairos Materials) in `data/datasets.yml`.

ELEMENTA is a composition-complete, prototype-independent first-principles dataset: unary, binary and ternary compositions with up to twelve atoms per cell (~1.9M reduced formulas) are systematically enumerated and explored via random structure search, yielding 210,656,285 DFT-labeled frames (energies, forces, stresses) over 9,781,175 distinct relaxed polymorphs (VASP, MPRelaxSet protocol, PBE+U, PAW). For the training of the models submitted to Matbench Discovery, structures overlapping with the WBM benchmark test set were removed during post-processing. Expansion sets: ELEMENTA Spin (4.7M frames, magnetic-moment scans) and ELEMENTA Vib (~8M perturbed structures).

- Technical report: https://www.kairosmaterials.com/papers/ELEMENTA.pdf (DOI: https://doi.org/10.5281/zenodo.22638068)
- Open subset (~39M core frames + complete 4.7M ELEMENTA Spin, extended XYZ, 17.7 GB, CC-BY-NC-4.0): https://huggingface.co/datasets/kairosmaterial/ELEMENTA
- Full corpus is closed, hence `open: false` with the released subset's license, following the GNoME/MatterSim precedent.

A follow-up model submission PR will reference this dataset in its `training_sets`.
